### PR TITLE
Custom check images in column header

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -9287,6 +9287,8 @@ var
             with Header.Treeview do
             begin
               ColImageInfo.Images := GetCheckImageListFor(CheckImageKind);
+              if not Assigned(ColImageInfo.Images) then
+                ColImageInfo.Images := CustomCheckImages;
               ColImageInfo.Index := GetCheckImage(nil, FCheckType, FCheckState, IsEnabled);
               ColImageInfo.XPos := GlyphPos.X;
               ColImageInfo.YPos := GlyphPos.Y;


### PR DESCRIPTION
When using checkboxes in the column header, the custom check image list must be used as needed to avoid access violations.
