### PR TITLE
Fix for Issue 572

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -14481,6 +14481,8 @@ begin
           StructureChange(nil, crChildAdded)
         else
           StructureChange(Node, crChildAdded);
+
+        ReinitNode(Node, True);
       end;
     end;
   end;


### PR DESCRIPTION
When the node count changes, the node and its children must be reinited so that derived classes can act upon that change. This is particularly useful for TCustomVirtualStringTree
