### PR TITLE
Fix for Issue 571

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -30377,7 +30377,7 @@ begin
                             begin
                               // These variables and the nested if conditions shall make the logic
                               // easier to understand.
-                              CellIsTouchingClientRight := PaintInfo.CellRect.Right = Window.Right;
+                              CellIsTouchingClientRight := PaintInfo.CellRect.Right = ClientRect.Right;
                               CellIsInLastColumn := Position = TColumnPosition(Count - 1);
                               ColumnIsFixed := coFixed in FHeader.FColumns[Column].Options;
 


### PR DESCRIPTION
CellIsTouchingClientRight should check ClientRect and not Window because Window can be a subrectangle of the full client rect (when invaliding a column, for instance)
