### PR TITLE
Fix for Issue 603

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -14779,7 +14779,7 @@ begin
       Include(Node.States, vsFiltered);
       if not (toShowFilteredNodes in FOptions.FPaintOptions) then
       begin
-        if vsInitializing in Node.States then
+        if (vsInitializing in Node.States) and not (vsHasChildren in Node.States) then
           AdjustTotalHeight(Node, 0, False)
         else
           AdjustTotalHeight(Node, -Integer(NodeHeight[Node]), True);


### PR DESCRIPTION
If the node already has children, then its nodeheight is valid and we must not remove its total height, but rather its height. (Issue #603)
