### PR TITLE
New option to set the way of selecting next cell for editing, minor fix to prevent AV

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -32846,9 +32846,12 @@ begin
           Tree.InvalidateNode(FLink.FNode);
           NextNode := Tree.GetNextVisible(FLink.FNode, True);
           Tree.EndEditNode;
-          Tree.FocusedNode := NextNode;
-          if Tree.CanEdit(Tree.FocusedNode, Tree.FocusedColumn) then
-            Tree.DoEdit;
+          if NextNode <> nil then
+          begin
+            Tree.FocusedNode := NextNode;
+            if Tree.CanEdit(Tree.FocusedNode, Tree.FocusedColumn) then
+              Tree.DoEdit;
+          end;
         end;
       end;
     Ord('A'):


### PR DESCRIPTION
Like in topic title: Small bug fix and new feature feature to set the way of selecting next cells for editing.

Editing style can be set globally or for each of cell individually to select other cell for editing (simple edit navigation at runtime without any code).
