### PR TITLE
Fixed issue #653: GetFirstVisibleChild/NoInit check for wrong node

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -27404,7 +27404,7 @@ begin
   Result := GetFirstChild(Node);
 
   if Assigned(Result) and (not (vsVisible in Result.States) or
-     (not IncludeFiltered and IsEffectivelyFiltered[Node])) then
+     (not IncludeFiltered and IsEffectivelyFiltered[Result])) then
     Result := GetNextVisibleSibling(Result, IncludeFiltered);
 end;
 
@@ -27419,7 +27419,7 @@ begin
     Node := FRoot;
   Result := Node.FirstChild;
   if Assigned(Result) and (not (vsVisible in Result.States) or
-     (not IncludeFiltered and IsEffectivelyFiltered[Node])) then
+     (not IncludeFiltered and IsEffectivelyFiltered[Result])) then
     Result := GetNextVisibleSiblingNoInit(Result, IncludeFiltered);
 end;
 


### PR DESCRIPTION
The patch fixes issue #653 where the wrong node was used for the IsEffectivelyFiltered check. This causes GetFirstVisibleChild/NoInit to return a node that may be filtered if the parent node (`Node`) is not filtered itself and IncludeFiltered=True is specified.

The patch replaces the (wrong) parent-node with the first child node.
