### PR TITLE
Fix AV when tree is modified in OnEdited event

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -22468,6 +22468,8 @@ begin
   if (tsEditing in FStates) then begin
     if not DoEndEdit then
       exit;
+    // Repeat the hit test as an OnEdited event might got triggered that could modify the tree.
+    GetHitTestInfoAt(Message.XPos, Message.YPos, True, HitInfo);
   end;//if tsEditing
 
   // Focus change. Don't use the SetFocus method as this does not work for MDI Winapi.Windows.


### PR DESCRIPTION
Fixea access violation when user clicks on some node when editing another and the hitted node is deleted in OnEdited event 
