### PR TITLE
Use HighlightText instead of NodeFontColor as fallback for selected nodes

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -12114,7 +12114,7 @@ begin
         begin
           if not StyleServices.GetElementColor(StyleServices.GetElementDetails(ttItemSelected), ecTextColor, Result) or
             (Result <> clWindowText) then
-            Result := NodeFontColor;
+            Result := StyleServices.GetSystemColor(clHighlightText);
         end
         else
           Result := FColors[Index];


### PR DESCRIPTION
Small drawing enhancement when VCL Styles are used.
Use HighlightText instead of NodeFontColor as fallback when the StyleServices don't return anything useful for ttItemSelected
Normally NodeFontColor is dark (in a light design) and it is not easy to read on a blue highlight background for selected items.