### PR TITLE
Add TBaseVirtualTree.OnAddHeaderPopupItem event and 'Size Column to Fit' menu item to TVTHeaderPopupMenu

### DIFF
--- a/Source/VTHeaderPopup.pas
+++ b/Source/VTHeaderPopup.pas
@@ -78,22 +78,15 @@ type
   );
   TVTHeaderPopupOptions = set of TVTHeaderPopupOption;
 
-  TAddPopupItemType = (
-    apNormal,
-    apDisabled,
-    apHidden
-  );
-
-  TAddHeaderPopupItemEvent = procedure(const Sender: TBaseVirtualTree; const Column: TColumnIndex;
-    var Cmd: TAddPopupItemType) of object;
   TColumnChangeEvent = procedure(const Sender: TBaseVirtualTree; const Column: TColumnIndex; Visible: Boolean) of object;
 
   TVTHeaderPopupMenu = class(TPopupMenu)
   strict private
     FOptions: TVTHeaderPopupOptions;
 
-    FOnAddHeaderPopupItem: TAddHeaderPopupItemEvent;
+    FOnHeaderAddPopupItem: TVTHeaderAddPopupItemEvent;
     FOnColumnChange: TColumnChangeEvent;
+    procedure ResizeColumnToFit(Sender: TObject);
     procedure ResizeToFit(Sender: TObject);
   strict protected
     procedure DoAddHeaderPopupItem(const Column: TColumnIndex; out Cmd: TAddPopupItemType); virtual;
@@ -105,7 +98,7 @@ type
   published
     property Options: TVTHeaderPopupOptions read FOptions write FOptions default [poResizeToFitItem];
 
-    property OnAddHeaderPopupItem: TAddHeaderPopupItemEvent read FOnAddHeaderPopupItem write FOnAddHeaderPopupItem;
+    property OnAddHeaderPopupItem: TVTHeaderAddPopupItemEvent read FOnHeaderAddPopupItem write FOnHeaderAddPopupItem;
     property OnColumnChange: TColumnChangeEvent read FOnColumnChange write FOnColumnChange;
   end;
 
@@ -117,7 +110,8 @@ uses
   Winapi.Windows;
 
 resourcestring
-  sResizeToFit = '&Resize All Columns To Fit';
+  sResizeColumnToFit = 'Size &Column to Fit';
+  sResizeToFit = 'Size &All Columns to Fit';
 
 type
   TVTMenuItem = class(TMenuItem)
@@ -137,8 +131,8 @@ procedure TVTHeaderPopupMenu.DoAddHeaderPopupItem(const Column: TColumnIndex; ou
 
 begin
   Cmd := apNormal;
-  if Assigned(FOnAddHeaderPopupItem) then
-    FOnAddHeaderPopupItem((PopupComponent as TBaseVirtualTree), Column, Cmd);
+  if Assigned(FOnHeaderAddPopupItem) then
+    FOnHeaderAddPopupItem((PopupComponent as TBaseVirtualTree), Column, Cmd);
 end;
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -190,7 +184,9 @@ begin
         Items[i].Free;
     end;//for i
 
-    if poResizeToFitItem in Self.Options then begin
+    if poResizeToFitItem in Self.Options then
+    begin
+      Items.Add(TVTMenuItem.Create(Self, sResizeColumnToFit, ResizeColumnToFit));
       Items.Add(TVTMenuItem.Create(Self, sResizeToFit, ResizeToFit));
       Items.Add(TVTMenuItem.Create(Self, cLineCaption));
     end;//poResizeToFitItem
@@ -240,8 +236,19 @@ begin
         VisibleItem.Enabled := False;
     end;
   end;
-  
+
   inherited;
+end;
+
+procedure TVTHeaderPopupMenu.ResizeColumnToFit(Sender: TObject);
+var
+  P: TPoint;
+  Column: TColumnIndex;
+begin
+  P := TBaseVirtualTree(PopupComponent).ScreenToClient(PopupPoint);
+  Column := TBaseVirtualTree(PopupComponent).Header.Columns.ColumnFromPosition(P);
+  if Column <> InvalidColumn then
+    TBaseVirtualTree(PopupComponent).Header.AutoFitColumns(True, smaUseColumnOption, Column, Column);
 end;
 
 procedure TVTHeaderPopupMenu.ResizeToFit(Sender: TObject);


### PR DESCRIPTION
- create new OnHeaderAddPopupItem event that links to the internal FColumnPopupMenu's OnAddHeaderPopupItem
- add new 'Size Column to Fit' menu item to TVTHeaderPopupMenu
- change sResizeToFit string to match Windows 10
- move TAddPopupItemType type to VirtualTrees.pas
- rename TAddHeaderPopupItemEvent to TVTHeaderAddPopupItemEvent and move to VirtualTrees.pas
- rename private TVTHeaderPopupMenu.FOnAddHeaderPopupItem to TVTHeaderPopupMenu.FOnHeaderAddPopupItem to match type name (OnAddHeaderPopupItem event is not renamed for compatibility)
- fix header popup menus position (offset Y by -FHeader.FHeight)
