### PR TITLE
Very slow popup if popup menu is not set only aquired from OnGetPopup…

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -18143,7 +18143,8 @@ begin
       Invalidate;
     end;
 
-    inherited;
+    if Assigned(PopupMenu) then
+      inherited;
 
     // get information about the hit
     GetHitTestInfoAt(Message.XPos, Message.YPos, True, HitInfo);


### PR DESCRIPTION
When tree have not popup menu set only that manu is selected in
OnGetPopupMenu event it show on the screen with big delay. Removing
inherited here solve the problem