### PR TITLE
Fixed a bug where hints of type hmTooltip had incorrect (random) position

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -16298,7 +16298,9 @@ begin
                     begin
                       ShowOwnHint := True;
                       NodeRect := GetDisplayRect(HitInfo.HitNode, HitInfo.HitColumn, True, False);
-                    end;
+                    end
+                    else
+                      ShowOwnHint := False;
                   end
                   else
                   begin


### PR DESCRIPTION
When a hint of a type hmTooltip is used in conjunction with a node which has vsMultiline node state and hit position is anything other than hiOnItemLabel, the local variable NodeRect is not updated (so its values are whatever random data was on stack), but its values are nevertheless used for calculating the hint position.
They are erroneously used because ShowOwnHint is not returned to False when hit position is != hiOnItemLabel.