### PR TITLE
Fixed a bug where scroll bars are not shown when a node with children is initialized with ivsExpanded.

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -32937,7 +32937,10 @@ begin
             InvalidateNode(Node);
         end
         else
+        begin
           UpdateRanges;
+          UpdateScrollBars(True);
+        end;
       end;
 
     finally


### PR DESCRIPTION
Fixed a bug where scroll bars are not shown when a node with children is initialized with ivsExpanded.

Take a look at the attached example which reproduces the bug, run it and click on button1.
[scrollbars_missing.zip](https://github.com/Virtual-TreeView/Virtual-TreeView/files/2047359/scrollbars_missing.zip)