### PR TITLE
Fixed a bug in header painting when the form maximizes and hoAutoResize is set.

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -1379,7 +1379,7 @@ type
       RangeStartCol: Integer = NoColumn; RangeEndCol: Integer = NoColumn); virtual;
     function InHeader(P: TPoint): Boolean; virtual;
     function InHeaderSplitterArea(P: TPoint): Boolean; virtual;
-    procedure Invalidate(Column: TVirtualTreeColumn; ExpandToBorder: Boolean = False);
+    procedure Invalidate(Column: TVirtualTreeColumn; ExpandToBorder: Boolean = False; UpdateNowFlag : Boolean = False);
     procedure LoadFromStream(const Stream: TStream); virtual;
     function ResizeColumns(ChangeBy: Integer; RangeStartCol: TColumnIndex; RangeEndCol: TColumnIndex;
       Options: TVTColumnOptions = [coVisible]): Integer;
@@ -8020,10 +8020,10 @@ begin
   if NewIndex <> OldIndex then
   begin
     if OldIndex > NoColumn then
-      FHeader.Invalidate(Items[OldIndex]);
+      FHeader.Invalidate(Items[OldIndex], False, True);
     OldIndex := NewIndex;
     if OldIndex > NoColumn then
-      FHeader.Invalidate(Items[OldIndex]);
+      FHeader.Invalidate(Items[OldIndex], False, True);
     Result := True;
   end;
 end;
@@ -11534,7 +11534,7 @@ end;
 
 //----------------------------------------------------------------------------------------------------------------------
 
-procedure TVTHeader.Invalidate(Column: TVirtualTreeColumn; ExpandToBorder: Boolean = False);
+procedure TVTHeader.Invalidate(Column: TVirtualTreeColumn; ExpandToBorder: Boolean = False; UpdateNowFlag : Boolean = False);
 
 // Because the header is in the non-client area of the tree it needs some special handling in order to initiate its
 // repainting.
@@ -11544,6 +11544,7 @@ procedure TVTHeader.Invalidate(Column: TVirtualTreeColumn; ExpandToBorder: Boole
 
 var
   R, RW: TRect;
+  Flags: Cardinal;
 
 begin
   if (hoVisible in FOptions) and Treeview.HandleAllocated then
@@ -11583,8 +11584,10 @@ begin
 
       // Expressed in client coordinates (because RedrawWindow wants them so, they will actually become negative).
       MapWindowPoints(0, Handle, R, 2);
-      RedrawWindow(Handle, @R, 0, RDW_FRAME or RDW_INVALIDATE or RDW_UPDATENOW or RDW_VALIDATE or RDW_NOINTERNALPAINT or
-        RDW_NOERASE or RDW_NOCHILDREN);
+      Flags := RDW_FRAME or RDW_INVALIDATE or RDW_VALIDATE or RDW_NOINTERNALPAINT or RDW_NOERASE or RDW_NOCHILDREN;
+      if UpdateNowFlag then
+        Flags := Flags or RDW_UPDATENOW;
+      RedrawWindow(Handle, @R, 0, Flags);
     end;
 end;
 


### PR DESCRIPTION
The solution for issue #726 (commit ff68b02f4033d192c26d82bee5b5a1856560f110) has introduced a regression in header painting. 
The header is not properly repainted after a form with a VST ( with Align = alClient and hoAutoResize in Header.Options ) is maximized.

See the provided example project. Run it, move the window to the top of the screen (to avoid triggering a repaint with the mouse) and maximize the window. The right side of the header is not repainted properly.
[HeaderBug.zip](https://github.com/Virtual-TreeView/Virtual-TreeView/files/2064484/HeaderBug.zip)

I've fixed the bug by including the flag RDW_UPDATENOW (introduced by ff68b02f4033d192c26d82bee5b5a1856560f110) only if the Invalidate method is invoked because of a mouse hover.