### PR TITLE
Clear VST's FocusedNode if the focused node becomes filtered and toShowFilteredNodes is not in FOptions.FPaintOptions.

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -15030,6 +15030,8 @@ begin
           Dec(FVisibleCount);
           NeedUpdate := True;
         end;
+        if FocusedNode = Node then
+          FocusedNode := nil;
       end;
 
       if FUpdateCount = 0 then


### PR DESCRIPTION
This commit makes VST clear its FocusedNode if the focused node becomes filtered and toShowFilteredNodes is not in FOptions.FPaintOptions.
An invisible node can not be focused anyway.