### PR TITLE
Don't crash DWM with a gigantic tooltip hint window

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -17978,6 +17978,13 @@ begin
                   else
                   begin
                     NodeRect := GetDisplayRect(HitInfo.HitNode, HitInfo.HitColumn, True, True, True);
+
+                    //[Avatar-20181112] Don't show a tooltip that is large enough to crash the DWM compositer!
+                    //There's no reason for a hint rect to be 43,000 pixels wide.
+                    //The Windows ListView control, for example, truncates tooltips to 263 characters, and Screen Width wide.
+                    NodeRect.Width  := Math.Min(NodeRect.Width,  GetSystemMetrics(SM_CXVIRTUALSCREEN));
+                    NodeRect.Height := Math.Min(NodeRect.Height, GetSystemMetrics(SM_CYVIRTUALSCREEN));
+
                     BottomRightCellContentMargin := DoGetCellContentMargin(HitInfo.HitNode, HitInfo.HitColumn, ccmtBottomRightOnly);
 
                     ShowOwnHint := (HitInfo.HitColumn > InvalidColumn) and PtInRect(NodeRect, CursorPos) and

--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -7333,7 +7333,7 @@ var
 begin
   // See if we already have a format of that type available.
   Index := FindFormatEtc(FormatEtc, FormatEtcArray);
-  if Index > - 1 then
+  if Index >= 0 then
   begin
     // Just use the TFormatEct in the array after releasing the data.
     LocalStgMedium := FindInternalStgMedium(FormatEtcArray[Index].cfFormat);


### PR DESCRIPTION
Don't show a tooltip that is large enough to crash the DWM compositor!

There's no reason for a hint rect to be 43,000 pixels wide. The Windows LISTVIEW control, for example, truncates tooltips to 263 characters, and Screen Width wide.