### PR TITLE
Always try to fetch colors via StyleServices if these are enabled

### DIFF
--- a/Packages/RAD Studio 10.3/VirtualTreesD.dproj
+++ b/Packages/RAD Studio 10.3/VirtualTreesD.dproj
@@ -119,8 +119,7 @@
                     <VersionInfoKeys Name="ProductVersion">1.0.0.0</VersionInfoKeys>
                     <VersionInfoKeys Name="Comments"/>
                 </VersionInfoKeys>
-                <Excluded_Packages />
- 
+                <Excluded_Packages/>
             </Delphi.Personality>
             <Platforms>
                 <Platform value="Win32">True</Platform>

--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -11756,10 +11756,9 @@ end;
 
 function TVTColors.GetColor(const Index: TVTColorEnum): TColor;
 begin
-  Result := FColors[Index];
-  // Only fetch the color via StyleServices if it is the default color
-  // Return user defined color otherwise
-  if (Result = cDefaultColors[Index]) and FOwner.VclStyleEnabled and not StyleServices.IsSystemStyle then
+  // Only try to fetch the color via StyleServices if theses are enabled
+  // Return default/user defined color otherwise
+  if FOwner.VclStyleEnabled and not StyleServices.IsSystemStyle then
     begin
       // If the ElementDetails are not defined, fall back to the SystemColor
       case Index of
@@ -11787,7 +11786,9 @@ begin
         else
           Result := StyleServices.GetSystemColor(FColors[Index]);
       end;
-    end;
+    end
+  else
+    Result := FColors[Index];
 end;
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Following up on #858 'Fixed colors in GetColor' I removed the check for default colors.
GetColor() will always try to fetch a color via StyleServices if these are enabled. This handles the case that the user swaps system colors around.