### PR TITLE
Deterministic Freeing of Workerthread with concurrency fix and do not return Imageindex without imagelist

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -19927,23 +19927,18 @@ function TBaseVirtualTree.DoGetImageIndex(Node: PVirtualNode; Kind: TVTImageKind
 const
   cTVTImageKind2String: Array [TVTImageKind] of string = ('ikNormal', 'ikSelected', 'ikState', 'ikOverlay');
 begin
+  if Kind = ikState then
+    Result := Self.StateImages
+  else
+    Result := Self.Images;
   // First try the enhanced event to allow for custom image lists.
-  if Assigned(FOnGetImageEx) then begin
-    if Kind = ikState then
-      Result := Self.StateImages
-    else
-      Result := Self.Images;
-    FOnGetImageEx(Self, Node, Kind, Column, Ghosted, Index, Result);
-  end
-  else begin
-    if Kind = ikState then
-      Result := Self.StateImages
-    else
-      Result := Self.Images;
-    if Assigned(FOnGetImage) then
-      FOnGetImage(Self, Node, Kind, Column, Ghosted, Index);
-  end;
-  Assert((Index < 0) or Assigned(Result), 'An image index was supplied for TVTImageKind.' + cTVTImageKind2String[Kind] + ' but no image list was supplied.');
+  if Assigned(FOnGetImageEx) then
+    FOnGetImageEx(Self, Node, Kind, Column, Ghosted, Index, Result)
+  else if Assigned(FOnGetImage) then
+    FOnGetImage(Self, Node, Kind, Column, Ghosted, Index);
+
+  if not Assigned(Result) then
+    Index := -1;
 end;
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
We have leak checking in our application and tests and they keep failing at times when the application reaches the leakcheck faster than the TWorkerThread being freed. 

I modified the code so that TWorkerThread.ReleaseReference and the called method Dispose have an optional flag "CanBlock". If set, Dispose will set FreeOnTerminate to false and free the thread at the end manually.

That way, i can now call AddReference at startup and ReleaseReference(True) when closing before the leakcheck.

And DoGetImageIndex will nolonger return an Imageindex, if no Imagelist is returned, to avoid AVs

PS: please forgive me the broken diff on the Workerthread. I have no clue why that one is broken.
PSS: oh we can ignore WHiteSpace differences here, too