### PR TITLE
use proper background for toggle animation

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -32015,7 +32015,15 @@ var
     begin
       Window := Handle;
       DC := GetDC(Handle);
-      Self.Brush.Color := FColors.BackGroundColor;
+      
+      if (toShowBackground in FOptions.FPaintOptions) and Assigned(FBackground.Graphic) then
+        Self.Brush.Style := bsClear
+      else
+      begin
+        Self.Brush.Style := bsSolid;
+        Self.Brush.Color := FColors.BackGroundColor;
+      end;  
+
       Brush := Self.Brush.Handle;
 
       if (Mode1 <> tamNoScroll) and (Mode2 <> tamNoScroll) then


### PR DESCRIPTION
Use Image Background in Toggle animation instead of fixed color one

We are using VirtualTreeView for side menu and this change is required to fix visual glitches (images below)
Before 
![2019-12-11-08-50-28](https://user-images.githubusercontent.com/1270275/70602379-9c82a800-1bf4-11ea-8db8-438f0d65937a.gif)

After
![2019-12-11-08-50-43](https://user-images.githubusercontent.com/1270275/70602383-9e4c6b80-1bf4-11ea-8f38-0678c744baf5.gif)