### PR TITLE
Implemented #964 EmptyListMessage should show when no visible nodes.

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -30884,7 +30884,7 @@ begin
           NodeBitmap.Free;
       end;//try..finally
       
-      if (ChildCount[nil] = 0) and (FEmptyListMessage <> '') then
+      if (FEmptyListMessage <> '') and  ((ChildCount[nil] = 0) or (GetFirstVisible = nil)) then
       begin
         // output a message if no items are to display
         Canvas.Font := Self.Font;


### PR DESCRIPTION
Shows EmptyListMessage when there are no visible nodes. Also a minor optimization - only check if there are nodes if we have an EmptyListMessage. 