### PR TITLE
Provide access to current hot column by introducing a new property "HotColumn"

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -3216,6 +3216,7 @@ type
     property HasChildren[Node: PVirtualNode]: Boolean read GetHasChildren write SetHasChildren;
     property Header: TVTHeader read FHeader write SetHeader;
     property HotNode: PVirtualNode read FCurrentHotNode write SetHotNode;
+    property HotColumn: TColumnIndex read FCurrentHotColumn;
     property IsDisabled[Node: PVirtualNode]: Boolean read GetDisabled write SetDisabled;
     property IsEffectivelyFiltered[Node: PVirtualNode]: Boolean read GetEffectivelyFiltered;
     property IsEffectivelyVisible[Node: PVirtualNode]: Boolean read GetEffectivelyVisible;


### PR DESCRIPTION
At the moment only the property HotNode is public, so one cannot determine the current column for hottracking. With this change you have the column too and so you can apply hottrack highlighting to the cell only. For example:
```
procedure TFormXX.VirtualStringTreeXBeforeCellPaint(Sender: TBaseVirtualTree;
  TargetCanvas: TCanvas; Node: PVirtualNode; Column: TColumnIndex;
  CellPaintMode: TVTCellPaintMode; CellRect: TRect; var ContentRect: TRect);
begin
  if (Node = VirtualStringTree1.HotNode) and (Column = VirtualStringTree1.HotColumn) then
    TargetCanvas.Brush.Color := clLime
  else
    TargetCanvas.Brush.Color := clWhite;
  TargetCanvas.FillRect(ContentRect);
end;
```