### PR TITLE
Added solution from attached issue (#749)

### DIFF
--- a/Packages/RAD Studio 10.3/VirtualTreesD.dproj
+++ b/Packages/RAD Studio 10.3/VirtualTreesD.dproj
@@ -1,4 +1,4 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <ProjectGuid>{A34BA07B-19B6-4C21-9DEE-65FCA52D00AB}</ProjectGuid>
         <MainSource>VirtualTreesD.dpk</MainSource>
@@ -38,7 +38,7 @@
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <DllSuffix>26</DllSuffix>
         <DesignOnlyPackage>true</DesignOnlyPackage>
-        <DCC_UnitSearchPath>..\..\source;.\$(Platform)\$(Config);$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\..\source;.\$(Platform)\$(Config);$(BDSCOMMONDIR)\dcp;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <VerInfo_Locale>1053</VerInfo_Locale>
         <DCC_E>false</DCC_E>


### PR DESCRIPTION
Delphi 10.3 CE doesn't put $(BDSCOMMONDIR)\dcp on library path. So specified that explicitly, and only after that was able to install components.


$(BDSCOMMONDIR)\dcp