### PR TITLE
HighDPI - column widths not scaling when min and max width are the same.

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -1045,6 +1045,7 @@ type
     procedure SetWidth(Value: TDimension);
   protected
     FLeft: TDimension;
+    procedure ChangeScale(M, D: TDimension; isDpiChange: Boolean); virtual;
     procedure ComputeHeaderLayout(var PaintInfo: THeaderPaintInfo; DrawFormat: Cardinal;  CalculateTextRect: Boolean = False);
     procedure DefineProperties(Filer: TFiler); override;
     procedure GetAbsoluteBounds(var Left, Right: TDimension);
@@ -7087,6 +7088,14 @@ end;
 
 //----------------------------------------------------------------------------------------------------------------------
 
+procedure TVirtualTreeColumn.ChangeScale(M, D: TDimension; isDpiChange: Boolean);
+begin
+  FMinWidth := MulDiv(FMinWidth, M, D);
+  FMaxWidth := MulDiv(FMaxWidth, M, D);
+  FSpacing  := MulDiv(FSpacing, M, D);
+  Self.Width := MulDiv(Self.Width, M, D);
+end;
+
 procedure TVirtualTreeColumn.ComputeHeaderLayout(var PaintInfo: THeaderPaintInfo; DrawFormat: Cardinal;  CalculateTextRect: Boolean = False);
 
 // The layout of a column header is determined by a lot of factors. This method takes them all into account and
@@ -9998,9 +10007,7 @@ begin
     Font.Height := MulDiv(Font.Height, M, D);
   // Scale the columns widths too
   for I := 0 to FColumns.Count - 1 do
-  begin
-    Self.FColumns[I].Width := MulDiv(Self.FColumns[I].Width, M, D);
-  end;//for I
+    Self.FColumns[I].ChangeScale(M, D, isDpiChange);
   if not isDpiChange then
     AutoScale();
 end;


### PR DESCRIPTION
Scaling did not take column minwidth & maxwith into account.

This changes seems to fix it, however I now see a ... on the last column of one VT in my app that wasn't there before this change.  I haven't figured out what that is or where it is in the code.