### PR TITLE
Add property 'TVirtualTreeColumn.LastWidth'

### DIFF
--- a/Source/VirtualTrees.Header.pas
+++ b/Source/VirtualTrees.Header.pas
@@ -145,6 +145,7 @@ type
 
     property BonusPixel : Boolean read FBonusPixel write FBonusPixel;
     property CaptionText : string read FCaptionText;
+    property LastWidth : TDimension read FLastWidth;
     property Left : TDimension read GetLeft;
     property Owner : TVirtualTreeColumns read GetOwner;
     property SpringRest : Single read FSpringRest write FSpringRest;


### PR DESCRIPTION
Add a public read-only property `TVirtualTreeColumn.LastWidth` for accessing the value of private field `FLastWidth`.
Thus, the delta width could be calculated in event `OnColumnResize`.