### PR TITLE
[FMX port]RenderOleData, ShiftState, IsFocused, Color

### DIFF
--- a/Source/VirtualTrees.AncestorVcl.pas
+++ b/Source/VirtualTrees.AncestorVcl.pas
@@ -5,19 +5,143 @@ unit VirtualTrees.AncestorVCL;
 {****************************************************************************************************************}
 { Project          : VirtualTrees                                                                                }
 {                                                                                                                }
-{ author           : Karol Bieniaszewski                                                                         }
+{ author           : Karol Bieniaszewski, look at VirtualTrees.pas as some code moved from there                 }
 { year             : 2022                                                                                        }
 { contibutors      :                                                                                             }
 {****************************************************************************************************************}
 
 interface
-uses VirtualTrees.BaseTree;
+uses
+  Winapi.Windows,
+  Winapi.ActiveX,
+  VirtualTrees.BaseTree;
 
 type
-  TVTAncestorVcl = class abstract(TBaseVirtualTree)
-  protected
+  TVTRenderOLEDataEvent = procedure(Sender: TBaseVirtualTree; const FormatEtcIn: TFormatEtc; out Medium: TStgMedium;
+    ForClipboard: Boolean; var Result: HRESULT) of object;
 
+  TVTAncestorVcl = class abstract(TBaseVirtualTree)
+  private
+    FOnRenderOLEData: TVTRenderOLEDataEvent;     // application/descendant defined clipboard formats
+  protected
+    function DoRenderOLEData(const FormatEtcIn: TFormatEtc; out Medium: TStgMedium; ForClipboard: Boolean): HRESULT; virtual;
+    function RenderOLEData(const FormatEtcIn: TFormatEtc; out Medium: TStgMedium; ForClipboard: Boolean): HResult; virtual;
+
+    property OnRenderOLEData: TVTRenderOLEDataEvent read FOnRenderOLEData write FOnRenderOLEData;
   end;
 
 implementation
+uses
+  System.Classes,
+  VirtualTrees.ClipBoard,
+  Vcl.AxCtrls;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+function TVTAncestorVcl.RenderOLEData(const FormatEtcIn: TFormatEtc; out Medium: TStgMedium;
+  ForClipboard: Boolean): HResult;
+
+// Returns a memory expression of all currently selected nodes in the Medium structure.
+// Note: The memory requirement of this method might be very high. This depends however on the requested storage format.
+//       For HGlobal (a global memory block) we need to render first all nodes to local memory and copy this then to
+//       the global memory in Medium. This is necessary because we have first to determine how much
+//       memory is needed before we can allocate it. Hence for a short moment we need twice the space as used by the
+//       nodes alone (plus the amount the nodes need in the tree anyway)!
+//       With IStream this does not happen. We directly stream out the nodes and pass the constructed stream along.
+
+  //--------------- local function --------------------------------------------
+
+  procedure WriteNodes(Stream: TStream);
+
+  var
+    Selection: TNodeArray;
+    I: Integer;
+
+  begin
+    if ForClipboard then
+      Selection := GetSortedCutCopySet(True)
+    else
+      Selection := GetSortedSelection(True);
+    for I := 0 to High(Selection) do
+      WriteNode(Stream, Selection[I]);
+  end;
+
+  //--------------- end local function ----------------------------------------
+
+var
+  Data: PCardinal;
+  ResPointer: Pointer;
+  ResSize: Integer;
+  OLEStream: IStream;
+  VCLStream: TStream;
+
+begin
+  ZeroMemory (@Medium, SizeOf(Medium));
+
+  // We can render the native clipboard format in two different storage media.
+  if (FormatEtcIn.cfFormat = CF_VIRTUALTREE) and (FormatEtcIn.tymed and (TYMED_HGLOBAL or TYMED_ISTREAM) <> 0) then
+  begin
+    VCLStream := nil;
+    try
+      Medium.unkForRelease := nil;
+      // Return data in one of the supported storage formats, prefer IStream.
+      if FormatEtcIn.tymed and TYMED_ISTREAM <> 0 then
+      begin
+        // Create an IStream on a memory handle (here it is 0 which indicates to implicitely allocated a handle).
+        // Do not use TStreamAdapter as it is not compatible with OLE (when flushing the clipboard OLE wants the HGlobal
+        // back which is not supported by TStreamAdapater).
+        CreateStreamOnHGlobal(0, True, OLEStream);
+        VCLStream := TOLEStream.Create(OLEStream);
+        WriteNodes(VCLStream);
+        // Rewind stream.
+        VCLStream.Position := 0;
+        Medium.tymed := TYMED_ISTREAM;
+        IUnknown(Medium.stm) := OLEStream;
+        Result := S_OK;
+      end
+      else
+      begin
+        VCLStream := TMemoryStream.Create;
+        WriteNodes(VCLStream);
+        ResPointer := TMemoryStream(VCLStream).Memory;
+        ResSize := VCLStream.Position;
+
+        // Allocate memory to hold the string.
+        if ResSize > 0 then
+        begin
+          Medium.hGlobal := GlobalAlloc(GHND or GMEM_SHARE, ResSize + SizeOf(Cardinal));
+          Data := GlobalLock(Medium.hGlobal);
+          // Store the size of the data too, for easy retrival.
+          Data^ := ResSize;
+          Inc(Data);
+          Move(ResPointer^, Data^, ResSize);
+          GlobalUnlock(Medium.hGlobal);
+          Medium.tymed := TYMED_HGLOBAL;
+
+          Result := S_OK;
+        end
+        else
+          Result := E_FAIL;
+      end;
+    finally
+      // We can free the VCL stream here since it was either a pure memory stream or only a wrapper around
+      // the OLEStream which exists independently.
+      VCLStream.Free;
+    end;
+  end
+  else // Ask application descendants to render self defined formats.
+    Result := DoRenderOLEData(FormatEtcIn, Medium, ForClipboard);
+end;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+function TVTAncestorVcl.DoRenderOLEData(const FormatEtcIn: TFormatEtc; out Medium: TStgMedium;
+  ForClipboard: Boolean): HRESULT;
+
+begin
+  Result := E_FAIL;
+  if Assigned(FOnRenderOLEData) then
+    FOnRenderOLEData(Self, FormatEtcIn, Medium, ForClipboard, Result);
+end;
+
 end.

--- a/Source/VirtualTrees.BaseAncestorFMX.pas
+++ b/Source/VirtualTrees.BaseAncestorFMX.pas
@@ -19,6 +19,9 @@ type
   strict private
     FFont: TFont;
     procedure SetFont(const Value: TFont);
+  private
+    function GetFillColor: TAlphaColor;
+    procedure SetFillColor(const Value: TAlphaColor);
   protected
     FDottedBrush: TStrokeBrush;                  // used to paint dotted lines without special pens
     FDottedBrushGrid: TStrokeBrush;              // used to paint dotted lines without special pens
@@ -56,7 +59,7 @@ type
     
     procedure ChangeScale(M, D: Integer{$if CompilerVersion >= 31}; isDpiChange: Boolean{$ifend}); virtual; abstract;
     function GetControlsAlignment: TAlignment; virtual; abstract;	
-  public
+  public //properties
     property Font: TFont read FFont write SetFont;
     property ClientRect: TRect read GetClientRect;
     property ClientWidth: Single read GetClientWidth;
@@ -72,6 +75,11 @@ type
     property HScrollBar: TScrollBar read FHScrollBar;
     property VScrollBar: TScrollBar read FVScrollBar;
 
+    /// <summary>
+    /// Alias for Fill.Color to make same use as Vcl Color property
+    /// </summary>
+	  property Color: TAlphaColor read GetFillColor write SetFillColor;
+  public //methods
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
 
@@ -86,10 +94,30 @@ type
     function GetScrollBarForBar(Bar: Integer): TScrollBar;
     procedure HScrollChangeProc(Sender: TObject);
     procedure VScrollChangeProc(Sender: TObject);
+	
+    /// <summary>
+    /// Alias for IsFocused to make same as Vcl Focused
+    /// </summary>
+    function Focused(): Boolean; inline;
+	
+    /// <summary>
+    /// Convert mouse message to TMouseButton
+	/// Created as method, to be available in whole hierarchy without specifing Unit file name (prevent circular unit ref).
+    /// </summary>
+    class function KeysToShiftState(Keys: LongInt): TShiftState; static;
   end;
 
 implementation
 uses FMX.TextLayout, FMX.Utils;
+
+//-------- TVTBaseAncestorFMX ------------------------------------------------------------------------------------------
+
+class function TVTBaseAncestorFMX.KeysToShiftState(Keys: LongInt): TShiftState;
+begin
+  Result := TShiftState(Word(Keys));
+end;
+
+//----------------------------------------------------------------------------------------------------------------------
 
 function TVTBaseAncestorFMX.GetClientHeight: Single;
 begin
@@ -101,6 +129,13 @@ end;
 function TVTBaseAncestorFMX.GetClientWidth: Single;
 begin
   Result:= ClientRect.Width;
+end;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+function TVTBaseAncestorFMX.GetFillColor: TAlphaColor;
+begin
+  Result:= Fill.Color;
 end;
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -426,10 +461,23 @@ end;
 
 //----------------------------------------------------------------------------------------------------------------------
 
+procedure TVTBaseAncestorFMX.SetFillColor(const Value: TAlphaColor);
+begin
+  Fill.Color:= Value;
+end;
+
+//----------------------------------------------------------------------------------------------------------------------
+
 procedure TVTBaseAncestorFMX.SetFont(const Value: TFont);
 begin
   FFont.Assign(Value);
 end;
 
+//----------------------------------------------------------------------------------------------------------------------
+
+function TVTBaseAncestorFMX.Focused(): Boolean
+begin
+  Result:= IsFocused;
+end;
 
 end.

--- a/Source/VirtualTrees.BaseAncestorVcl.pas
+++ b/Source/VirtualTrees.BaseAncestorVcl.pas
@@ -5,18 +5,24 @@ unit VirtualTrees.BaseAncestorVCL;
 {****************************************************************************************************************}
 { Project          : VirtualTrees                                                                                }
 {                                                                                                                }
-{ author           : Karol Bieniaszewski                                                                         }
+{ author           : Karol Bieniaszewski, look at VirtualTrees.pas as some code moved from there                 }
 { year             : 2022                                                                                        }
 { contibutors      :                                                                                             }
 {****************************************************************************************************************}
 
 interface
-uses Vcl.Controls;
+uses
+  Winapi.Windows,
+  Winapi.ActiveX,
+  Vcl.Controls;
 
 type
   TVTBaseAncestorVcl = class abstract(TCustomControl)
-  protected
+  private
 
+  protected
+    function DoRenderOLEData(const FormatEtcIn: TFormatEtc; out Medium: TStgMedium; ForClipboard: Boolean): HRESULT; virtual; abstract;
+    function RenderOLEData(const FormatEtcIn: TFormatEtc; out Medium: TStgMedium; ForClipboard: Boolean): HResult; virtual; abstract;
   end;
 
 implementation


### PR DESCRIPTION
1. Moved RenderOleData to Vcl specific units.
2. Introduce KeysToShiftState, as method, to be available in whole hierarchy (FMX) without specifing Unit file name (prevent circular unit ref).
3. Introduce Focused function as an alias for IsFocused property on FMX to be compatible with Vcl.
4. Introduce Color property as an alias for Fill.Color on FMX to be compatible with Vcl.