### PR TITLE
[FMX port]Copy, cut, paste move and some other small changes

### DIFF
--- a/Source/VirtualTrees.AncestorFMX.pas
+++ b/Source/VirtualTrees.AncestorFMX.pas
@@ -19,6 +19,13 @@ type
     procedure MouseDown(Button: TMouseButton; Shift: TShiftState; X: Single; Y: Single); override;
     procedure MouseUp(Button: TMouseButton; Shift: TShiftState; X: Single; Y: Single); override;
     procedure MouseWheel(Shift: TShiftState; WheelDelta: Integer; var Handled: Boolean); override;
+
+    //TODO: CopyCutPaste - need to be implemented
+    {
+    function PasteFromClipboard(): Boolean; override;
+    procedure CopyToClipboard(); override;
+    procedure CutToClipboard(); override;
+    }
   end;
 
 implementation

--- a/Source/VirtualTrees.BaseAncestorFMX.pas
+++ b/Source/VirtualTrees.BaseAncestorFMX.pas
@@ -94,15 +94,19 @@ type
     function GetScrollBarForBar(Bar: Integer): TScrollBar;
     procedure HScrollChangeProc(Sender: TObject);
     procedure VScrollChangeProc(Sender: TObject);
-	
+
+    procedure CopyToClipboard; virtual; abstract;
+    procedure CutToClipboard; virtual; abstract;
+    function PasteFromClipboard: Boolean; virtual; abstract;
+
     /// <summary>
     /// Alias for IsFocused to make same as Vcl Focused
     /// </summary>
     function Focused(): Boolean; inline;
-	
+
     /// <summary>
     /// Convert mouse message to TMouseButton
-	/// Created as method, to be available in whole hierarchy without specifing Unit file name (prevent circular unit ref).
+    /// Created as method, to be available in whole hierarchy without specifing Unit file name (prevent circular unit ref).
     /// </summary>
     class function KeysToShiftState(Keys: LongInt): TShiftState; static;
   end;

--- a/Source/VirtualTrees.BaseAncestorVcl.pas
+++ b/Source/VirtualTrees.BaseAncestorVcl.pas
@@ -28,6 +28,10 @@ type
     function DoRenderOLEData(const FormatEtcIn: TFormatEtc; out Medium: TStgMedium; ForClipboard: Boolean): HRESULT; virtual; abstract;
     function RenderOLEData(const FormatEtcIn: TFormatEtc; out Medium: TStgMedium; ForClipboard: Boolean): HResult; virtual; abstract;
     procedure NotifyAccessibilityCollapsed(); virtual; abstract;
+  public // methods
+    procedure CopyToClipboard; virtual; abstract;
+    procedure CutToClipboard; virtual; abstract;
+    function PasteFromClipboard: Boolean; virtual; abstract;
   public //properties
     property Accessible: IAccessible read FAccessible write FAccessible;
     property AccessibleItem: IAccessible read FAccessibleItem write FAccessibleItem;


### PR DESCRIPTION
1. Moved copy, cut, paste code to VCL and provided in ancestors.
2. Renamed ShowError to RaiseVTError and made it class function.
3. Changed InterlockedIncrement to AtomicIncrement which is common name for all platforms and is aliased in Windows to InterlockedIncrement.
4. Some helper dummy vars as TDimension.