### PR TITLE
Fix horizontal position of right aligned content in last column

### DIFF
--- a/Source/VirtualTrees.BaseTree.pas
+++ b/Source/VirtualTrees.BaseTree.pas
@@ -21191,9 +21191,11 @@ begin
                                   end;
 
                                   Dec(CellRect.Right);
-                                  Dec(ContentRect.Right);
                                 end;
                               end;
+                              // Reduce the content rect size nonetheless to retain correct alignment
+                              // relative to header content (especially if "PaintInfo.Alignment = alRightJustify").
+                              Dec(ContentRect.Right);
                             end;
                           end;
 


### PR DESCRIPTION
### Current situation

In `TBaseVirtualTree.GetMaxColumnWidth` one pixel is always added if vertical grid lines are enabled; see [in code](https://github.com/JAM-Software/Virtual-TreeView/blob/f9a5ee02bbe93fb61d31847c6339ba48637588ee/Source/VirtualTrees.BaseTree.pas#L18411).

On the other hand, under certain conditions, a vertical grid line - despite enabled - is not painted; see [`TBaseVirtualTree.PaintTree`](https://github.com/JAM-Software/Virtual-TreeView/blob/f9a5ee02bbe93fb61d31847c6339ba48637588ee/Source/VirtualTrees.BaseTree.pas#L21165).

### Problem

Expected cell content distances:
![image](https://github.com/JAM-Software/Virtual-TreeView/assets/25772356/405be0ab-10ac-439a-825d-8b3b9ee07a38)
Note: Screenshot made _after_ applying proposed solution.

Actual cell content distances:
![image](https://github.com/JAM-Software/Virtual-TreeView/assets/25772356/ad8aed5d-3cde-4683-bcbc-7b0617a367d3)
The `TextMargin` area of the right-aligned content overlaps the non-painted vertical grid line space.

In both cases, both columns are auto-sized to the same width. Please note, that the right-aligned text of column "_alRight_" is offset by one to the right under current behaviour. Thus, it looks like the auto-sizing resulted in a width one pixel too wide.

### Proposal

Improve method `TBaseVirtualTree.PaintTree` by reducing content rect size, even if the rightmost vertical grid line is not painted depite being enabled in general. Thus, cell content is aligned correctly relative to header content (especially if "PaintInfo.Alignment = alRightJustify").