### PR TITLE
Fix drawing of tree lines

### DIFF
--- a/Source/VirtualTrees.BaseTree.pas
+++ b/Source/VirtualTrees.BaseTree.pas
@@ -3510,7 +3510,7 @@ begin
   if Reverse then
     TargetX := 0
   else
-    TargetX := FIndent + ScaledPixels(FImagesMargin);
+    TargetX := FIndent - 1;
 
   with PaintInfo.Canvas do
   begin


### PR DESCRIPTION
- changed method `TBaseVirtualTree.DrawLineImage` to not wrongly apply (scaled) `FImagesMargin` anymore
- instead (if `not Reverse`) simply use `FIndent` decreased by one pixel to draw the line just next to a node