### PR TITLE
Reduce circular links

### DIFF
--- a/Source/VirtualTrees.AccessibilityFactory.pas
+++ b/Source/VirtualTrees.AccessibilityFactory.pas
@@ -37,7 +37,7 @@
 interface
 
 uses
-  System.Classes, Winapi.oleacc, VirtualTrees, VirtualTrees.BaseTree;
+  System.Classes, Winapi.oleacc, VirtualTrees.BaseTree;
 
 type
   IVTAccessibleProvider = interface

--- a/Source/VirtualTrees.Actions.pas
+++ b/Source/VirtualTrees.Actions.pas
@@ -7,7 +7,6 @@ uses
   System.Actions,
   Vcl.Controls,
   Vcl.ActnList,
-  VirtualTrees,
   VirtualTrees.Types,
   VirtualTrees.BaseTree;
 

--- a/Source/VirtualTrees.BaseTree.pas
+++ b/Source/VirtualTrees.BaseTree.pas
@@ -1669,10 +1669,8 @@ uses
   VirtualTrees.WorkerThread,
   VirtualTrees.ClipBoard,
   VirtualTrees.Utils,
-  VirtualTrees.Export,
   VirtualTrees.HeaderPopup,
-  VirtualTrees.DragnDrop,
-  VirtualTrees.EditLink;
+  VirtualTrees.DragnDrop;
 
 resourcestring
   // Localizable strings.

--- a/Source/VirtualTrees.ClipBoard.pas
+++ b/Source/VirtualTrees.ClipBoard.pas
@@ -32,8 +32,6 @@ uses
   Winapi.Windows,
   Winapi.ActiveX,
   System.Classes,
-  VirtualTrees,
-  VirtualTrees.Types,
   VirtualTrees.BaseTree;
 
 type

--- a/Source/VirtualTrees.Colors.pas
+++ b/Source/VirtualTrees.Colors.pas
@@ -101,7 +101,6 @@ implementation
 
 uses
   WinApi.Windows,
-  VirtualTrees,
   VirtualTrees.Types,
   VirtualTrees.Utils,
   VirtualTrees.StyleHooks,

--- a/Source/VirtualTrees.DataObject.pas
+++ b/Source/VirtualTrees.DataObject.pas
@@ -58,7 +58,6 @@ type
 implementation
 
 uses
-  VirtualTrees,
   VirtualTrees.ClipBoard,
   VirtualTrees.DragnDrop,
   VirtualTrees.BaseTree;

--- a/Source/VirtualTrees.DragImage.pas
+++ b/Source/VirtualTrees.DragImage.pas
@@ -74,7 +74,6 @@ uses
   WinApi.Messages,
   System.SysUtils,
   System.Math,
-  VirtualTrees,
   VirtualTrees.DragnDrop,
   VirtualTrees.Types,
   VirtualTrees.Utils,

--- a/Source/VirtualTrees.DragnDrop.pas
+++ b/Source/VirtualTrees.DragnDrop.pas
@@ -9,7 +9,6 @@ uses
   System.Types,
   Vcl.Graphics,
   Vcl.Controls,
-  VirtualTrees,
   VirtualTrees.Types,
   VirtualTrees.BaseTree;
 

--- a/Source/VirtualTrees.DrawTree.pas
+++ b/Source/VirtualTrees.DrawTree.pas
@@ -5,12 +5,23 @@ interface
 uses
   System.Types,
   System.Classes,
+  Vcl.Themes,
   VirtualTrees.Types,
-  VirtualTrees,
-  VirtualTrees.BaseTree;
-
+  VirtualTrees.BaseTree,
+{$IFDEF VT_FMX}
+  VirtualTrees.AncestorFMX,
+{$ELSE}
+  VirtualTrees.AncestorVCL
+{$ENDIF}
+  ;
 
 type
+{$IFDEF VT_FMX}
+  TVTAncestor = TVTAncestorFMX;
+{$ELSE}
+  TVTAncestor = TVTAncestorVcl;
+{$ENDIF}
+
   // Tree descendant to let an application draw its stuff itself.
   TCustomVirtualDrawTree = class(TVTAncestor)
   private
@@ -263,6 +274,9 @@ type
 
 implementation
 
+uses
+  VirtualTrees.StyleHooks;
+
 //----------------------------------------------------------------------------------------------------------------------
 
 function TCustomVirtualDrawTree.DoGetCellContentMargin(Node: PVirtualNode; Column: TColumnIndex;
@@ -329,6 +343,10 @@ begin
   Result := TVirtualTreeOptions;
 end;
 
+initialization
+  TCustomStyleEngine.RegisterStyleHook(TVirtualDrawTree, TVclStyleScrollBarsHook);
 
+finalization
+  TCustomStyleEngine.UnRegisterStyleHook(TVirtualDrawTree, TVclStyleScrollBarsHook);
 
 end.

--- a/Source/VirtualTrees.Header.pas
+++ b/Source/VirtualTrees.Header.pas
@@ -452,7 +452,6 @@ uses
   System.Math,
   System.SysUtils,
   Vcl.Forms,
-  VirtualTrees,
   VirtualTrees.HeaderPopup,
   VirtualTrees.BaseTree,
   VirtualTrees.BaseAncestorVcl{to eliminate H2443 about inline expanding}

--- a/Source/VirtualTrees.HeaderPopup.pas
+++ b/Source/VirtualTrees.HeaderPopup.pas
@@ -68,7 +68,6 @@ interface
 uses
   System.Classes,
   Vcl.Menus,
-  VirtualTrees,
   VirtualTrees.Types,
   VirtualTrees.BaseTree;
 

--- a/Source/VirtualTrees.StyleHooks.pas
+++ b/Source/VirtualTrees.StyleHooks.pas
@@ -140,10 +140,9 @@ uses
   System.SysUtils,
   System.Math,
   System.Types,
-  VirtualTrees,
   VirtualTrees.Header,
   VirtualTrees.Types,
-  VirtualTrees.DrawTree;
+  VirtualTrees.BaseTree;
 
 function VTStyleServices(AControl: TControl = nil): TCustomStyleServices;
 begin
@@ -1085,13 +1084,5 @@ begin
   end;
 end;
 {$ifend}
-
-initialization
-  TCustomStyleEngine.RegisterStyleHook(TVirtualStringTree, TVclStyleScrollBarsHook);
-  TCustomStyleEngine.RegisterStyleHook(TVirtualDrawTree, TVclStyleScrollBarsHook);
-
-finalization
-  TCustomStyleEngine.UnRegisterStyleHook(TVirtualStringTree, TVclStyleScrollBarsHook);
-  TCustomStyleEngine.UnRegisterStyleHook(TVirtualDrawTree, TVclStyleScrollBarsHook);
 
 end.

--- a/Source/VirtualTrees.Types.pas
+++ b/Source/VirtualTrees.Types.pas
@@ -1091,7 +1091,6 @@ implementation
 
 uses
   System.TypInfo,
-  VirtualTrees,
   VirtualTrees.StyleHooks,
   VirtualTrees.BaseTree,
   VirtualTrees.BaseAncestorVcl{to eliminate H2443 about inline expanding}

--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -2003,11 +2003,10 @@ begin
   Self.ExportType := pExportType;
 end;
 
-
 initialization
+  TCustomStyleEngine.RegisterStyleHook(TVirtualStringTree, TVclStyleScrollBarsHook);
 
 finalization
+  TCustomStyleEngine.UnRegisterStyleHook(TVirtualStringTree, TVclStyleScrollBarsHook);
 
 end.
-
-


### PR DESCRIPTION
Significantly reduce circular links for simplified maintenance and easier compilation. The goal is to make base layer (base tree with helper classes) independent from VST (with export and accessibility) and draw tree