### PR TITLE
Sort and cleanup used units

### DIFF
--- a/Design/VirtualTreesReg.pas
+++ b/Design/VirtualTreesReg.pas
@@ -11,8 +11,7 @@ interface
 {$warn UNSAFE_CODE off}
 
 uses
-  Windows, Classes, DesignIntf, DesignEditors, VCLEditors, PropertyCategories,
-  ColnEdit, VirtualTrees, VirtualTrees.DrawTree, VirtualTrees.HeaderPopup, VirtualTrees.BaseTree;
+  DesignEditors;
 
 type
   TVirtualTreeEditor = class (TDefaultEditor)
@@ -27,8 +26,12 @@ procedure Register;
 implementation
 
 uses
-  StrEdit, Dialogs, TypInfo, SysUtils, Graphics, CommCtrl, ImgList, Controls,
-  VirtualTrees.ClipBoard, VirtualTrees.Actions;
+  WinApi.Windows, WinApi.CommCtrl,
+  System.TypInfo, System.SysUtils, System.Classes,
+  StrEdit,DesignIntf, VCLEditors, PropertyCategories, ColnEdit,
+  Vcl.Dialogs, Vcl.Graphics, Vcl.ImgList, Vcl.Controls,
+  VirtualTrees.ClipBoard, VirtualTrees.Actions, VirtualTrees, VirtualTrees.DrawTree,
+  VirtualTrees.HeaderPopup, VirtualTrees.BaseTree;
 
 type
   // The usual trick to make a protected property accessible in the ShowCollectionEditor call below.

--- a/Source/VirtualTrees.Accessibility.pas
+++ b/Source/VirtualTrees.Accessibility.pas
@@ -8,8 +8,10 @@
 interface
 
 uses
-  Winapi.Windows, System.Classes, Winapi.ActiveX, System.Types, Winapi.oleacc,
-  VirtualTrees, VirtualTrees.AccessibilityFactory, Vcl.Controls, VirtualTrees.BaseTree;
+  Winapi.Windows, Winapi.ActiveX, Winapi.oleacc,
+  System.Classes, System.Types,
+  Vcl.Controls,
+  VirtualTrees, VirtualTrees.AccessibilityFactory, VirtualTrees.BaseTree;
 
 type
   TVirtualTreeAccessibility = class(TInterfacedObject, IDispatch, IAccessible)
@@ -99,7 +101,8 @@ type
 implementation
 
 uses
-  System.SysUtils, Vcl.Forms, System.Variants, System.Math,
+  System.SysUtils, System.Variants, System.Math,
+  Vcl.Forms,
   VirtualTrees.Types;
 
 type

--- a/Source/VirtualTrees.AccessibilityFactory.pas
+++ b/Source/VirtualTrees.AccessibilityFactory.pas
@@ -37,7 +37,9 @@
 interface
 
 uses
-  System.Classes, Winapi.oleacc, VirtualTrees.BaseTree;
+  Winapi.oleacc,
+  System.Classes,
+  VirtualTrees.BaseTree;
 
 type
   IVTAccessibleProvider = interface

--- a/Source/VirtualTrees.BaseTree.pas
+++ b/Source/VirtualTrees.BaseTree.pas
@@ -27,10 +27,12 @@ interface
 {$HPPEMIT '#pragma link "VirtualTrees.Accessibility"'}
 
 uses
-  Winapi.Windows, Winapi.Messages, System.SysUtils, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.ImgList, Winapi.ActiveX, Vcl.StdCtrls, System.Classes,
-  Vcl.Menus, Vcl.Printers, System.Types, Winapi.CommCtrl, Vcl.Themes, Winapi.UxTheme,
-  Winapi.ShlObj, System.UITypes, System.Generics.Collections,
+  Winapi.Windows, Winapi.Messages, Winapi.ActiveX, Winapi.CommCtrl,
+  Winapi.UxTheme, Winapi.ShlObj,
+  System.SysUtils, System.Classes, System.Types,
+  Vcl.Graphics, Vcl.Controls, Vcl.Forms, Vcl.ImgList, Vcl.StdCtrls,
+  Vcl.Menus, Vcl.Printers, Vcl.Themes,
+  System.UITypes, // some types moved from Vcl.* to System.UITypes
   VirtualTrees.Types,
   VirtualTrees.Colors,
   VirtualTrees.DragImage,
@@ -1654,23 +1656,18 @@ implementation
 {$R VirtualTrees.res}
 
 uses
-  Vcl.Consts,
-  System.Math,
-  Vcl.AxCtrls,                 // TOLEStream
   Winapi.MMSystem,             // for animation timer (does not include further resources)
-  System.TypInfo,              // for migration stuff
+  System.Math,
   System.SyncObjs,
-  Vcl.ActnList,
-  Vcl.StdActns,                // for standard action support
   System.StrUtils,
+  Vcl.Consts,
+  Vcl.AxCtrls,                 // TOLEStream
+  Vcl.StdActns,                // for standard action support
   Vcl.GraphUtil,               // accessibility helper class
   VirtualTrees.StyleHooks,
-  VirtualTrees.Classes,
-  VirtualTrees.DataObject,
   VirtualTrees.WorkerThread,
   VirtualTrees.ClipBoard,
   VirtualTrees.Utils,
-  VirtualTrees.HeaderPopup,
   VirtualTrees.DragnDrop;
 
 resourcestring

--- a/Source/VirtualTrees.DataObject.pas
+++ b/Source/VirtualTrees.DataObject.pas
@@ -5,8 +5,8 @@ interface
 uses
   WinApi.ActiveX,
   WinApi.Windows,
-  VirtualTrees.Types,
-  Vcl.Controls;
+  Vcl.Controls,
+  VirtualTrees.Types;
 
 type
   IDataObject = WinApi.ActiveX.IDataObject;

--- a/Source/VirtualTrees.Export.pas
+++ b/Source/VirtualTrees.Export.pas
@@ -19,14 +19,14 @@ procedure ContentToCustom(Tree: TCustomVirtualStringTree; Source: TVSTTextSource
 implementation
 
 uses
-  Vcl.Graphics,
-  Vcl.Controls,
-  Vcl.Forms,
   System.Classes,
   System.SysUtils,
   System.StrUtils,
   System.Generics.Collections,
   System.UITypes,
+  Vcl.Graphics,
+  Vcl.Controls,
+  Vcl.Forms,
   VirtualTrees.Types,
   VirtualTrees.ClipBoard,
   VirtualTrees.Header,

--- a/Source/VirtualTrees.Header.pas
+++ b/Source/VirtualTrees.Header.pas
@@ -3,18 +3,18 @@
 interface
 
 uses
+  WinApi.Windows,
+  WinApi.Messages,
   System.Classes,
   System.Types,
   System.Generics.Collections,
-  WinApi.Windows,
-  WinApi.Messages,
   Vcl.Graphics,
   Vcl.Menus,
   Vcl.ImgList,
   Vcl.Controls,
   Vcl.Themes,
   Vcl.GraphUtil,
-  System.UITypes,
+  System.UITypes, // some types moved from Vcl.* to System.UITypes
   VirtualTrees.StyleHooks,
   VirtualTrees.Utils,
   VirtualTrees.Types,

--- a/Source/VirtualTrees.HeaderPopup.pas
+++ b/Source/VirtualTrees.HeaderPopup.pas
@@ -108,7 +108,8 @@ type
 implementation
 
 uses
-  Winapi.Windows, System.Types,
+  Winapi.Windows,
+  System.Types,
   VirtualTrees.Header;
 
 resourcestring

--- a/Source/VirtualTrees.Types.pas
+++ b/Source/VirtualTrees.Types.pas
@@ -6,15 +6,15 @@ uses
   WinApi.ActiveX,
   Winapi.Windows,
   Winapi.Messages,
+  System.Types,
+  System.Classes,
+  System.SysUtils,
   Vcl.Controls,
   Vcl.GraphUtil,
   Vcl.Themes,
   Vcl.Graphics,
   Vcl.ImgList,
-  System.Types,
-  System.Classes,
-  System.SysUtils,
-  System.UITypes;
+  System.UITypes; // some types moved from Vcl.* to System.UITypes
 
 {$MINENUMSIZE 1, make enumerations as small as possible}
 

--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -75,13 +75,10 @@ interface
 {$HPPEMIT '#pragma link "VirtualTrees.Accessibility"'}
 
 uses
-  Winapi.Windows, Winapi.oleacc, Winapi.Messages, System.SysUtils, Vcl.Graphics,
-  Vcl.Controls, Vcl.Forms, Vcl.ImgList, Winapi.ActiveX, Vcl.StdCtrls, System.Classes,
-  Vcl.Menus, Vcl.Printers, System.Types, Winapi.CommCtrl, Vcl.Themes, Winapi.UxTheme,
-  Winapi.ShlObj, System.UITypes, System.Generics.Collections,
+  Winapi.Windows, Winapi.Messages, Winapi.ActiveX,
+  System.Classes, System.SysUtils,
+  Vcl.Graphics, Vcl.Controls, Vcl.ImgList, Vcl.Menus, Vcl.Themes,
   VirtualTrees.Types,
-  VirtualTrees.Colors,
-  VirtualTrees.DragImage,
   VirtualTrees.Header,
   VirtualTrees.BaseTree,
 {$IFDEF VT_FMX}
@@ -593,26 +590,12 @@ type
 
 implementation
 uses
-  Vcl.Consts,
-  System.Math,
-  Vcl.AxCtrls,                 // TOLEStream
-  Winapi.MMSystem,             // for animation timer (does not include further resources)
   System.TypInfo,              // for migration stuff
-  System.SyncObjs,
-  Vcl.ActnList,
-  Vcl.StdActns,                // for standard action support
   System.StrUtils,
-  Vcl.GraphUtil,               // accessibility helper class
-  VirtualTrees.AccessibilityFactory,
   VirtualTrees.StyleHooks,
-  VirtualTrees.Classes,
-  VirtualTrees.DataObject,
-  VirtualTrees.WorkerThread,
   VirtualTrees.ClipBoard,
   VirtualTrees.Utils,
   VirtualTrees.Export,
-  VirtualTrees.HeaderPopup,
-  VirtualTrees.DragnDrop,
   VirtualTrees.EditLink,
   VirtualTrees.BaseAncestorVcl{to eliminate H2443 about inline expanding}
   ;


### PR DESCRIPTION
Used units are sorted WinApi > System > Vcl > VT with exception of System.UITypes in some places - it was located after Vcl.* to override types that were moved from Vcl.*. This also could be solved by defining type alias without breaking the sorting order...
Many unused units were removed from BaseTree and VirtualTrees (they became unused after splitting).