### PR TITLE
Add check for MainColumn when it need to be the FocusedColumn

### DIFF
--- a/Source/VirtualTrees.BaseTree.pas
+++ b/Source/VirtualTrees.BaseTree.pas
@@ -10603,7 +10603,9 @@ begin
     if Assigned(FFocusedNode) then
     begin
       // Make sure a valid column is set if columns are used and no column has currently the focus.
-      if FHeader.UseColumns and (not FHeader.Columns.IsValidColumn(FFocusedColumn)) then
+      // We should also check if the maincolumn is allowfocus
+      if FHeader.UseColumns and (not FHeader.Columns.IsValidColumn(FFocusedColumn))
+      and FHeader.AllowFocus(FHeader.MainColumn) then
         FFocusedColumn := FHeader.MainColumn;
       // Do automatic expansion of the newly focused node if enabled.
       if (toAutoExpand in FOptions.AutoOptions) and not (vsExpanded in FFocusedNode.States) then


### PR DESCRIPTION
DoFocusNode will slways set FFocusedColumn to MainColumn when FFocusedColumn is not a valid column, even coAllowFocus is not active on MainColumn.