### PR TITLE
Remove unnecessary IDataObject type in public interface

### DIFF
--- a/Source/VirtualTrees.Types.pas
+++ b/Source/VirtualTrees.Types.pas
@@ -143,8 +143,7 @@ type
   PDimension = ^Integer;
   TNodeHeight = NativeInt;
   TVTCursor = HCURSOR;
-  IDataObject= WinApi.ActiveX.IDataObject;
-  TVTDragDataObject = IDataObject;
+  TVTDragDataObject = WinApi.ActiveX.IDataObject;
   TVTBackground = TPicture;
   TVTPaintContext = HDC;
   TVTBrush = HBRUSH;


### PR DESCRIPTION
This IDataObject conflicts with a similar named object in other files when it's outputting the hpp files for c++