### PR TITLE
Fix wrong coordinates in WMContextMenu

### DIFF
--- a/Source/VirtualTrees.BaseTree.pas
+++ b/Source/VirtualTrees.BaseTree.pas
@@ -6481,7 +6481,7 @@ begin
   if not Assigned(PopupMenu) then begin
     // convert screen coordinates to client
     pt := ScreenToClient(Point(Message.XPos, Message.YPos));
-    GetHitTestInfoAt(Message.XPos, Message.YPos, True, HitInfo); // ShiftState is not used anyway here
+    GetHitTestInfoAt(pt.x, pt.y, True, HitInfo); // ShiftState is not used anyway here
     DoPopupMenu(HitInfo.HitNode, HitInfo.HitColumn, pt);
   end;
 


### PR DESCRIPTION
The correct coordinates weren't actually used to identify the current node.