### PR TITLE
Fix #632: header is missing from PaintTo and drawn for client-only WM_PRINT

### DIFF
--- a/Source/VirtualTrees.BaseTree.pas
+++ b/Source/VirtualTrees.BaseTree.pas
@@ -7949,6 +7949,8 @@ end;
 procedure TBaseVirtualTree.WMPaint(var Message: TWMPaint);
 var
   DC: HDC;
+  HeaderTarget: TRect;
+  BorderSize: TSize;
 begin
   if tsVCLDragging in FStates then
     ImageList_DragShowNolock(False);
@@ -7964,12 +7966,31 @@ begin
 
   if hoVisible in FHeader.Options then
   begin
-    DC := GetDCEx(Handle, 0, DCX_CACHE or DCX_CLIPSIBLINGS or DCX_WINDOW or DCX_VALIDATE);
-    if DC <> 0 then
-      try
-        FHeader.Columns.PaintHeader(DC, FHeaderRect, -FEffectiveOffsetX);
-    finally
-      ReleaseDC(Handle, DC);
+    if Message.DC <> 0 then
+    begin
+      // The caller supplied a device context, so this is a copy being rendered somewhere else
+      // (TWinControl.PaintTo), not a paint of the real window. The header has to go into that DC - fetching a
+      // window DC here would draw it onto the screen and leave the copy without a header, which is issue #632.
+      HeaderTarget := FHeaderRect;
+      if csPaintCopy in ControlState then
+      begin
+        // PaintTo draws the border itself and then moves the origin inside it, while FHeaderRect is relative to
+        // the outer window corner. Without this the header ends up offset by the border width and is clipped on
+        // the opposite edge. GetBorderDimensions returns negative values, so adding them shifts back.
+        BorderSize := GetBorderDimensions;
+        OffsetRect(HeaderTarget, BorderSize.cx, BorderSize.cy);
+      end;
+      FHeader.Columns.PaintHeader(Message.DC, HeaderTarget, -FEffectiveOffsetX);
+    end
+    else
+    begin
+      DC := GetDCEx(Handle, 0, DCX_CACHE or DCX_CLIPSIBLINGS or DCX_WINDOW or DCX_VALIDATE);
+      if DC <> 0 then
+        try
+          FHeader.Columns.PaintHeader(DC, FHeaderRect, -FEffectiveOffsetX);
+      finally
+        ReleaseDC(Handle, DC);
+      end;
     end;
   end;//if header visible
 end;
@@ -7992,7 +8013,10 @@ procedure TBaseVirtualTree.WMPrint(var Message: TWMPrint);
 begin
   // Draw only if the window is visible or visibility is not required.
   if ((Message.Flags and PRF_CHECKVISIBLE) = 0) or IsWindowVisible(Handle) then
-    Header.Columns.PaintHeader(Message.DC, FHeaderRect, -FEffectiveOffsetX);
+    // The header lives in the non-client area, so it must only be drawn when the caller asked for that part.
+    // Painting it for a PRF_CLIENT only request put it over the client area and corrupted the border (#632).
+    if (Message.Flags and PRF_NONCLIENT) <> 0 then
+      Header.Columns.PaintHeader(Message.DC, FHeaderRect, -FEffectiveOffsetX);
 
   inherited;
 end;

--- a/Tests/Tests.dpr
+++ b/Tests/Tests.dpr
@@ -17,6 +17,7 @@ uses
   VTOnEditCancelledTests in 'VTOnEditCancelledTests.pas',
   VTOnDrawTextTests in 'VTOnDrawTextTests.pas',
   VTCellSelectionTests in 'VTCellSelectionTests.pas',
+  VTPaintToIssue632Tests in 'VTPaintToIssue632Tests.pas',
   VirtualTrees.MouseUtils in 'VirtualTrees.MouseUtils.pas',
   VTCellSelectionTests.VisibilityForm in 'VTCellSelectionTests.VisibilityForm.pas' {VisibilityForm},
   VTCellSelectionTests.VTSelectionTestForm in 'VTCellSelectionTests.VTSelectionTestForm.pas' {SelectionTestForm};

--- a/Tests/VTPaintToIssue632Tests.pas
+++ b/Tests/VTPaintToIssue632Tests.pas
@@ -1,0 +1,168 @@
+unit VTPaintToIssue632Tests;
+
+// Regressionstest zu Issue #632 "Paint into device context via PrintTo or WM_PRINT".
+//
+// Der Header liegt im Nicht-Client-Bereich. Zwei Fehler machten das Rendern in einen
+// fremden DC unbrauchbar:
+//   1. WMPaint holte sich fuer den Header per GetDCEx einen Fenster-DC, statt den DC zu
+//      benutzen, den die Nachricht mitbringt. Eine Kopie via TWinControl.PaintTo bekam
+//      deshalb alles ausser dem Header - der landete stattdessen auf dem Bildschirm.
+//   2. WMPrint zeichnete den Header ohne Ruecksicht auf die PRF_-Flags, also auch bei
+//      einer reinen PRF_CLIENT-Anforderung. Dort gehoert er nicht hin.
+//
+// Gemessen wird offscreen ueber die Pixel einer auffaellig gefaerbten Kopfzeile, damit
+// das Ergebnis nicht von Fenstersichtbarkeit oder Theme abhaengt.
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  Classes,
+  System.Types,
+  Vcl.Forms,
+  Vcl.Graphics,
+  VirtualTrees;
+
+type
+  [TestFixture]
+  TVTPaintToIssue632Tests = class
+  strict private
+    fForm: TForm;
+    fTree: TVirtualStringTree;
+    /// Rendert in eine weisse Bitmap und liefert Anzahl und Bounding-Box der Header-Pixel.
+    function RenderAndMeasure(UsePrint: Boolean; Flags: Cardinal; out Bounds: TRect): Integer;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    /// PaintTo muss den Header mitkopieren (das eigentliche Symptom des Issues).
+    [Test]
+    procedure PaintToIncludesHeader;
+
+    /// und zwar an derselben Stelle wie WM_PRINT mit PRF_NONCLIENT.
+    [Test]
+    procedure PaintToPlacesHeaderLikeWmPrint;
+
+    /// WM_PRINT ohne PRF_NONCLIENT darf den Header NICHT zeichnen.
+    [Test]
+    procedure WmPrintClientOnlyOmitsHeader;
+
+    /// WM_PRINT mit PRF_NONCLIENT muss ihn zeichnen.
+    [Test]
+    procedure WmPrintNonClientIncludesHeader;
+  end;
+
+implementation
+
+uses
+  Winapi.Windows,
+  Winapi.Messages,
+  System.SysUtils,
+  VirtualTrees.Types,
+  VirtualTrees.Header;
+
+const
+  HeaderColor = clRed;
+
+procedure TVTPaintToIssue632Tests.Setup;
+begin
+  fForm := TForm.Create(nil);
+  fForm.SetBounds(0, 0, 420, 300);
+  fTree := TVirtualStringTree.Create(fForm);
+  fTree.Parent := fForm;
+  fTree.SetBounds(10, 10, 380, 200);
+  fTree.Header.Options := fTree.Header.Options + [hoVisible];
+  fTree.Header.Background := HeaderColor;
+  fTree.Header.Style := hsPlates; // ungethemed, damit die Farbe wirklich durchschlaegt
+  if fTree.Header.Columns.Count = 0 then
+    fTree.Header.Columns.Add.Width := 360;
+  fTree.RootNodeCount := 5;
+  fForm.Show;
+  Application.ProcessMessages;
+end;
+
+procedure TVTPaintToIssue632Tests.TearDown;
+begin
+  FreeAndNil(fForm);
+end;
+
+function TVTPaintToIssue632Tests.RenderAndMeasure(UsePrint: Boolean; Flags: Cardinal;
+  out Bounds: TRect): Integer;
+var
+  Bmp: Vcl.Graphics.TBitmap;
+  X, Y: Integer;
+begin
+  Result := 0;
+  Bounds := Rect(MaxInt, MaxInt, -1, -1);
+  Bmp := Vcl.Graphics.TBitmap.Create;
+  try
+    Bmp.PixelFormat := pf24bit;
+    Bmp.SetSize(fTree.Width, fTree.Height);
+    Bmp.Canvas.Brush.Color := clWhite;
+    Bmp.Canvas.FillRect(Rect(0, 0, Bmp.Width, Bmp.Height));
+
+    if UsePrint then
+      fTree.Perform(WM_PRINT, WPARAM(Bmp.Canvas.Handle), LPARAM(Flags))
+    else
+      fTree.PaintTo(Bmp.Canvas.Handle, 0, 0);
+
+    for Y := 0 to Bmp.Height - 1 do
+      for X := 0 to Bmp.Width - 1 do
+        if Bmp.Canvas.Pixels[X, Y] = HeaderColor then
+        begin
+          Inc(Result);
+          if X < Bounds.Left then Bounds.Left := X;
+          if Y < Bounds.Top then Bounds.Top := Y;
+          if X > Bounds.Right then Bounds.Right := X;
+          if Y > Bounds.Bottom then Bounds.Bottom := Y;
+        end;
+  finally
+    Bmp.Free;
+  end;
+end;
+
+procedure TVTPaintToIssue632Tests.PaintToIncludesHeader;
+var
+  Bounds: TRect;
+begin
+  Assert.IsTrue(RenderAndMeasure(False, 0, Bounds) > 0,
+    'PaintTo hat den Header nicht mitkopiert');
+end;
+
+procedure TVTPaintToIssue632Tests.PaintToPlacesHeaderLikeWmPrint;
+var
+  PaintToBounds, PrintBounds: TRect;
+  PaintToCount, PrintCount: Integer;
+begin
+  PaintToCount := RenderAndMeasure(False, 0, PaintToBounds);
+  PrintCount := RenderAndMeasure(True, PRF_CLIENT or PRF_NONCLIENT, PrintBounds);
+
+  Assert.AreEqual(PrintCount, PaintToCount, 'Anzahl der Header-Pixel weicht ab');
+  Assert.AreEqual(PrintBounds.Left, PaintToBounds.Left, 'Header horizontal versetzt');
+  Assert.AreEqual(PrintBounds.Top, PaintToBounds.Top, 'Header vertikal versetzt');
+  Assert.AreEqual(PrintBounds.Right, PaintToBounds.Right, 'Header rechts beschnitten');
+  Assert.AreEqual(PrintBounds.Bottom, PaintToBounds.Bottom, 'Header unten beschnitten');
+end;
+
+procedure TVTPaintToIssue632Tests.WmPrintClientOnlyOmitsHeader;
+var
+  Bounds: TRect;
+begin
+  Assert.AreEqual(0, RenderAndMeasure(True, PRF_CLIENT, Bounds),
+    'PRF_CLIENT allein darf den Header des Nicht-Client-Bereichs nicht zeichnen');
+end;
+
+procedure TVTPaintToIssue632Tests.WmPrintNonClientIncludesHeader;
+var
+  Bounds: TRect;
+begin
+  Assert.IsTrue(RenderAndMeasure(True, PRF_CLIENT or PRF_NONCLIENT, Bounds) > 0,
+    'PRF_NONCLIENT muss den Header zeichnen');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TVTPaintToIssue632Tests);
+
+end.


### PR DESCRIPTION
Fixes #632.

The header lives in the non-client area, and two separate mistakes made rendering the
tree into a caller supplied device context unusable — matching both halves of the
report ("PaintTo is missing the header" and "WM_PRINT kinda messes with the border").

### 1. PaintTo lost the header

`WMPaint` always fetched a window DC via `GetDCEx` to draw the header, ignoring the DC
that comes with the message. `TWinControl.PaintTo` performs `WM_PAINT` with the target
DC, so the client area ended up in the copy while the header was painted onto the real
window instead. It now paints into `Message.DC` when one is supplied.

### 2. …and then sat two pixels off

`PaintTo` draws the border itself and then moves the origin inside it, while
`FHeaderRect` is relative to the outer window corner. So the header came out shifted by
the border width and clipped on the opposite edge. `csPaintCopy` marks exactly that
case, and `GetBorderDimensions` returns negative values, so adding them shifts back.

### 3. WM_PRINT ignored the PRF_ flags

The header was drawn for every request, so a `PRF_CLIENT` only print painted the
non-client header over the client area. That is the corrupted border. It now checks
`PRF_NONCLIENT`.

### Measurements

Rendered into an off-screen bitmap, counting the pixels of a distinctively coloured
header, so the numbers do not depend on window visibility or theming (Delphi 13.1,
Win32):

| | before | after |
|---|---|---|
| `PaintTo` | 0 px | 304 px, rect (362,2)-(377,20) |
| `WM_PRINT`, `PRF_CLIENT` only | 38 px | 0 px |
| `WM_PRINT`, `PRF_CLIENT or PRF_NONCLIENT` | 304 px | 304 px, unchanged |
| `WM_PRINT`, `PRF_NONCLIENT` | 304 px | 304 px, unchanged |

`PaintTo` is now pixel identical to `WM_PRINT` with `PRF_NONCLIENT`.

### Tests

`Tests/VTPaintToIssue632Tests.pas` covers all four cases. Three fail without this
change; `WmPrintNonClientIncludesHeader` passes either way and is there to guard the
case that already worked against an over-correction.

The suite goes from 135 passed / 5 failed to 138 passed / 2 failed. The two remaining
failures are the pre-existing `TestCopyHTML1` / `TestCopyHTML2`, which also fail on an
unmodified `master` here.

`AllUnits` compiles without errors and without hints.
