### PR TITLE
Fixed classic header cells ignoring Header.Background

### DIFF
--- a/Source/VirtualTrees.Header.pas
+++ b/Source/VirtualTrees.Header.pas
@@ -5567,26 +5567,26 @@ var
       hsThickButtons :
         begin
           NormalButtonStyle := BDR_RAISEDINNER or BDR_RAISEDOUTER;
-          NormalButtonFlags := BF_LEFT or BF_TOP or BF_BOTTOM or BF_MIDDLE or BF_SOFT or BF_ADJUST;
+          NormalButtonFlags := BF_LEFT or BF_TOP or BF_BOTTOM or BF_SOFT or BF_ADJUST;
           PressedButtonStyle := BDR_RAISEDINNER or BDR_RAISEDOUTER;
           PressedButtonFlags := NormalButtonFlags or BF_RIGHT or BF_FLAT or BF_ADJUST;
         end;
       hsFlatButtons :
         begin
           NormalButtonStyle := BDR_RAISEDINNER;
-          NormalButtonFlags := BF_LEFT or BF_TOP or BF_BOTTOM or BF_MIDDLE or BF_ADJUST;
+          NormalButtonFlags := BF_LEFT or BF_TOP or BF_BOTTOM or BF_ADJUST;
           PressedButtonStyle := BDR_SUNKENOUTER;
-          PressedButtonFlags := BF_RECT or BF_MIDDLE or BF_ADJUST;
+          PressedButtonFlags := BF_RECT or BF_ADJUST;
         end;
     else
       // hsPlates or hsXPStyle, values are not used in the latter case
       begin
         NormalButtonStyle := BDR_RAISEDINNER;
-        NormalButtonFlags := BF_RECT or BF_MIDDLE or BF_SOFT or BF_ADJUST;
+        NormalButtonFlags := BF_RECT or BF_SOFT or BF_ADJUST;
         PressedButtonStyle := BDR_SUNKENOUTER;
-        PressedButtonFlags := BF_RECT or BF_MIDDLE or BF_ADJUST;
+        PressedButtonFlags := BF_RECT or BF_ADJUST;
         RaisedButtonStyle := BDR_RAISEDINNER;
-        RaisedButtonFlags := BF_LEFT or BF_TOP or BF_BOTTOM or BF_MIDDLE or BF_ADJUST;
+        RaisedButtonFlags := BF_LEFT or BF_TOP or BF_BOTTOM or BF_ADJUST;
       end;
     end;
   end;
@@ -5730,6 +5730,10 @@ var
           end
           else
           begin // Windows classic mode
+            // Fill the cell interior ourselves instead of via BF_MIDDLE: DrawEdge would always use
+            // clBtnFace and ignore Header.Background (identical result for the default clBtnFace).
+            TargetCanvas.Brush.Color := Header.Background;
+            TargetCanvas.FillRect(PaintRectangle);
             if IsDownIndex then
               DrawEdge(TargetCanvas.Handle, PaintRectangle, PressedButtonStyle, PressedButtonFlags)
             else

--- a/Tests/Tests.dpr
+++ b/Tests/Tests.dpr
@@ -21,6 +21,7 @@ uses
   VTPaintTreeIssue1074Tests in 'VTPaintTreeIssue1074Tests.pas',
   VTBandsIssue1091Tests in 'VTBandsIssue1091Tests.pas',
   VTFixedColumnDragIssue1377Tests in 'VTFixedColumnDragIssue1377Tests.pas',
+  VTHeaderBackgroundTests in 'VTHeaderBackgroundTests.pas',
   VTCellSelectionTests in 'VTCellSelectionTests.pas',
   VTSelectedCountIssue1197Tests in 'VTSelectedCountIssue1197Tests.pas',
   VTPaintToIssue632Tests in 'VTPaintToIssue632Tests.pas',

--- a/Tests/VTHeaderBackgroundTests.pas
+++ b/Tests/VTHeaderBackgroundTests.pas
@@ -1,0 +1,147 @@
+unit VTHeaderBackgroundTests;
+
+// Regression test for the classic (non-themed) header paint path ignoring Header.Background
+// inside the column cells.
+//
+// DrawBackground fills the area right of the last column with Header.Background, but
+// PaintColumnHeader painted the cells themselves via DrawEdge with BF_MIDDLE, which always
+// fills with clBtnFace - so a custom Header.Background only ever showed up in the filler
+// area. The fix fills the cell interior explicitly with Header.Background before drawing
+// the edges, which is pixel-identical for the default clBtnFace.
+
+interface
+
+uses
+  DUnitX.TestFramework,
+  Classes,
+  System.Types,
+  Vcl.Forms,
+  Vcl.Graphics,
+  VirtualTrees;
+
+type
+  [TestFixture]
+  TVTHeaderBackgroundTests = class
+  strict private
+    fForm: TForm;
+    fTree: TVirtualStringTree;
+    /// Renders the header offscreen and counts the pixels of the given color in the
+    /// horizontal range [FromX, ToX) of the header band (edges excluded).
+    function CountHeaderPixels(Color: TColor; FromX, ToX: Integer): Integer;
+    function BandArea(FromX, ToX: Integer): Integer;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    /// In classic mode the column cells must be filled with Header.Background.
+    [Test]
+    procedure ClassicCellsUseHeaderBackground;
+    /// With the default Header.Background the classic cells keep the clBtnFace look.
+    [Test]
+    procedure DefaultRenderingKeepsButtonFace;
+  end;
+
+implementation
+
+uses
+  Winapi.Windows,
+  System.SysUtils,
+  VirtualTrees.Types,
+  VirtualTrees.BaseTree;
+
+type
+  TTreeCracker = class(TBaseVirtualTree); // for DoStateChange
+
+const
+  BackColor = clRed;
+  ColumnWidth = 120;
+  ColumnCount = 2;
+
+procedure TVTHeaderBackgroundTests.Setup;
+var
+  I: Integer;
+begin
+  fForm := TForm.Create(nil);
+  fForm.SetBounds(0, 0, 420, 300);
+  fTree := TVirtualStringTree.Create(fForm);
+  fTree.Parent := fForm;
+  fTree.SetBounds(10, 10, 380, 240);
+  for I := 1 to ColumnCount do
+    fTree.Header.Columns.Add.Width := ColumnWidth; // no captions: no text pixels in the band
+  fTree.Header.Options := fTree.Header.Options + [hoVisible];
+  fForm.Show;
+  Application.ProcessMessages;
+
+  // Force the classic (non-themed) paint path regardless of the OS theme state.
+  TTreeCracker(fTree).DoStateChange([], [tsUseThemes]);
+end;
+
+procedure TVTHeaderBackgroundTests.TearDown;
+begin
+  FreeAndNil(fForm);
+end;
+
+function TVTHeaderBackgroundTests.CountHeaderPixels(Color: TColor; FromX, ToX: Integer): Integer;
+var
+  Bmp: Vcl.Graphics.TBitmap;
+  X, Y: Integer;
+begin
+  Result := 0;
+  Bmp := Vcl.Graphics.TBitmap.Create;
+  try
+    Bmp.PixelFormat := pf24bit;
+    Bmp.SetSize(fTree.ClientWidth, fTree.Header.Height);
+    Bmp.Canvas.Brush.Color := clFuchsia; // neutral ground, clashes with nothing under test
+    Bmp.Canvas.FillRect(Rect(0, 0, Bmp.Width, Bmp.Height));
+
+    fTree.Header.Columns.PaintHeader(Bmp.Canvas, Rect(0, 0, Bmp.Width, Bmp.Height), Point(0, 0));
+
+    for Y := 2 to Bmp.Height - 3 do // skip the top/bottom bevel rows
+      for X := FromX to ToX - 1 do
+        if Bmp.Canvas.Pixels[X, Y] = ColorToRGB(Color) then
+          Inc(Result);
+  finally
+    Bmp.Free;
+  end;
+end;
+
+function TVTHeaderBackgroundTests.BandArea(FromX, ToX: Integer): Integer;
+begin
+  Result := (fTree.Header.Height - 4) * (ToX - FromX);
+end;
+
+procedure TVTHeaderBackgroundTests.ClassicCellsUseHeaderBackground;
+var
+  CellPixels, FillerPixels: Integer;
+begin
+  fTree.Header.Background := BackColor;
+
+  // Sanity: the filler area right of the last column already honored Header.Background.
+  FillerPixels := CountHeaderPixels(BackColor, ColumnCount * ColumnWidth + 2, fTree.ClientWidth - 2);
+  Assert.IsTrue(FillerPixels > BandArea(ColumnCount * ColumnWidth + 2, fTree.ClientWidth - 2) div 2,
+    'Sanity: the filler area right of the columns must use Header.Background.');
+
+  // The actual regression: the cells themselves must be filled with it too.
+  CellPixels := CountHeaderPixels(BackColor, 2, ColumnCount * ColumnWidth - 2);
+  Assert.IsTrue(CellPixels > (BandArea(2, ColumnCount * ColumnWidth - 2) * 6) div 10,
+    Format('Classic column cells must use Header.Background (%d of %d band pixels found).',
+    [CellPixels, BandArea(2, ColumnCount * ColumnWidth - 2)]));
+end;
+
+procedure TVTHeaderBackgroundTests.DefaultRenderingKeepsButtonFace;
+var
+  CellPixels: Integer;
+begin
+  // Header.Background defaults to clBtnFace - the classic look must not change.
+  CellPixels := CountHeaderPixels(clBtnFace, 2, ColumnCount * ColumnWidth - 2);
+  Assert.IsTrue(CellPixels > (BandArea(2, ColumnCount * ColumnWidth - 2) * 6) div 10,
+    Format('Default classic cells must keep the clBtnFace fill (%d band pixels found).',
+    [CellPixels]));
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TVTHeaderBackgroundTests);
+
+end.


### PR DESCRIPTION
In the classic (non-themed) paint path, `DrawBackground` fills the area right of the last column with `Header.Background`, but `PaintColumnHeader` paints the column cells via `DrawEdge` with `BF_MIDDLE`, which always fills the interior with `clBtnFace`. A custom `Header.Background` therefore only ever showed up in the filler area right of the columns, never in the cells themselves - noticeable in any manually colored (e.g. dark) UI running without themes or VCL styles.

The fix fills the cell interior explicitly with `Header.Background` before drawing the edges (`BF_MIDDLE` removed from the button flag sets). For the default `clBtnFace` the rendering is pixel-identical, and the themed and VCL-styles paths are untouched.

`Tests/VTHeaderBackgroundTests.pas` renders the header offscreen and asserts both directions: the cells follow a custom `Header.Background` (fails without the fix), and the default rendering keeps the `clBtnFace` look (guards the no-change promise). Suite is green apart from the two known `TestCopyHTML` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)