### PR TITLE
Fixed TestCopyHTML1/2: expectations were generated on a 216 dpi machine

### DIFF
--- a/Tests/VTCellSelectionTests.pas
+++ b/Tests/VTCellSelectionTests.pas
@@ -51,6 +51,7 @@ type
       Node: PVirtualNode; Column: TColumnIndex; TextType: TVSTTextType;
       var CellText: string);
     procedure EnableMultiCellSelection(const ATree: TBaseVirtualTree = nil);
+    function BuildExpectedCellHTML(const ANodes: array of PVirtualNode): string;
   public
     [Setup]
     procedure Setup;
@@ -304,6 +305,63 @@ begin
     [toExtendedFocus, toMultiSelect, toMultiCellSelect] - [toFullRowSelect];
 end;
 
+function TCellSelectionTests.BuildExpectedCellHTML(const ANodes: array of PVirtualNode): string;
+
+// Builds the expected CF_HTML clipboard content for a rectangular col1..col3 cell selection
+// from the tree's ACTUAL metrics (font, header height, node heights, column widths). The
+// former hardcoded strings were generated on a 216 dpi machine (see PixelsPerInch in the
+// fixture's dfm) and failed on any other dpi because the exported pixel heights differ.
+
+const
+  CRLF = #13#10;
+  DocType = '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">';
+  HTMLIntro = '<html><head><META http-equiv=Content-Type content="text/html; charset=utf-8">' +
+    '</head><body><!--StartFragment-->';
+  HTMLExtro = '<!--EndFragment--></body></html>';
+  // Fixed-width offset header, mirroring MakeFragment in VirtualTrees.Export.pas.
+  DescriptionLength = Length('Version:1.0'#13#10) + Length('StartHTML:') + Length('EndHTML:') +
+    Length('StartFragment:') + Length('EndFragment:') + 4 * 10 {NumberLengthAndCR};
+var
+  LFragment, LFont: string;
+  LStartFragment, LEndFragment: Integer;
+  I, C: Integer;
+begin
+  LFont := Format('font-family: ''%s''; font-size: %dpt; font-style: normal; font-weight: normal; ' +
+    'text-decoration: none; color: #000000;', [FTree.Font.Name, FTree.Font.Size]);
+  LFragment :=
+    '<META http-equiv="Content-Type" content="text/html; charset=utf-8">' +
+    '<style type="text/css">' + CRLF +
+    '.default{' + LFont + '}' + CRLF +
+    '.header{' + LFont + '}' + CRLF +
+    '.noborder{border-style: none;padding-left: 4px; padding-right: 4px;}' + CRLF +
+    '.normalborder {vertical-align: top; border-right: none; border-left:none; border-top:none; ' +
+    'border-bottom: none;border-width: thin; border-style: dotted;padding-left: 4px; padding-right: 4px;}</style>' + CRLF +
+    '<table class="default" style="border-collapse: collapse;" bgcolor=#FFFFFF  border="1" frame=box cellspacing="0">' + CRLF +
+    '<tr class="header" style="padding-left: 4px; padding-right: 4px;">' + CRLF;
+  for C := col1 to col3 do
+    LFragment := LFragment + Format('<th height="%dpx" align=left bgcolor=#F0F0F0 width="%dpx">%s</th>',
+      [FTree.Header.Height, FTree.Header.Columns[C].Width, FTree.Header.Columns[C].Text]);
+  LFragment := LFragment + '</tr>' + CRLF;
+  for I := 0 to High(ANodes) do
+  begin
+    LFragment := LFragment + ' <tr class="default">' + CRLF;
+    for C := col1 to col3 do
+      LFragment := LFragment + Format(' <td class="normalborder"  height="%dpx" align=left>%s</td>',
+        [FTree.NodeHeight[ANodes[I]], FTree.Text[ANodes[I], C]]);
+    LFragment := LFragment + ' </tr>' + CRLF;
+  end;
+  LFragment := LFragment + '</table>';
+
+  LStartFragment := DescriptionLength + Length(DocType) + Length(HTMLIntro);
+  LEndFragment := LStartFragment + Length(LFragment);
+  Result := 'Version:1.0' + CRLF +
+    Format('StartHTML:%.8d', [DescriptionLength]) + CRLF +
+    Format('EndHTML:%.8d', [LEndFragment + Length(HTMLExtro)]) + CRLF +
+    Format('StartFragment:%.8d', [LStartFragment]) + CRLF +
+    Format('EndFragment:%.8d', [LEndFragment]) + CRLF +
+    DocType + HTMLIntro + LFragment + HTMLExtro;
+end;
+
 procedure TCellSelectionTests.DoChangeCellEvent(Sender: TBaseVirtualTree; const Cells: TVTCellArray);
 begin
   if Assigned(FChangeCellEventProc) then
@@ -545,7 +603,6 @@ var
   n3, n4: PVirtualNode;
   LText, LExpected: string;
   LTries: Integer;
-  LCompareSuccessful: LongBool;
 begin
   LTree := FTree;
   LTree.Font.Name := 'Tahoma';
@@ -584,17 +641,8 @@ begin
     end;
     // End unnecessary stuff
   until (LText <> '') or (LTries > MaxTries);
-  LExpected := 'Version:1.0'#$D#$A'StartHTML:00000097'#$D#$A'EndHTML:00001737'#$D#$A'StartFragment:00000269'#$D#$A'EndFragment:00001705'#$D#$A +
-  '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html><head><META http-equiv=Content-Type content="text/html; charset=utf-8"></head><body><!--StartFragment--><META http-equiv="Content-Type" content="text/html; charset=utf-8">'+
-  '<style type="text/css">'#$D#$A'.default{font-family: ''Tahoma''; font-size: 8pt; font-style: normal; font-weight: normal; text-decoration: none; color: #000000;}'#$D#$A +
-  '.header{font-family: ''Tahoma''; font-size: 8pt; font-style: normal; font-weight: normal; text-decoration: none; color: #000000;}'#$D#$A'.noborder{border-style: none;padding-left: 4px; padding-right: 4px;}'#$D#$A +
-  '.normalborder {vertical-align: top; border-right: none; border-left:none; border-top:none; border-bottom: none;border-width: thin; border-style: dotted;padding-left: 4px; padding-right: 4px;}</style>'#$D#$A +
-  '<table class="default" style="border-collapse: collapse;" bgcolor=#FFFFFF  border="1" frame=box cellspacing="0">'#$D#$A'<tr class="header" style="padding-left: 4px; padding-right: 4px;">'#$D#$A +
-  '<th height="17px" align=left bgcolor=#F0F0F0 width="50px">col2</th><th height="17px" align=left bgcolor=#F0F0F0 width="50px">col3</th><th height="17px" align=left bgcolor=#F0F0F0 width="50px">col4</th></tr>'#$D#$A+
-  ' <tr class="default">'#$D#$A' <td class="normalborder"  height="18px" align=left>3b</td> <td class="normalborder"  height="18px" align=left>3c</td> <td class="normalborder"  height="18px" align=left>3d</td> </tr>'#$D#$A+
-  ' <tr class="default">'#$D#$A' <td class="normalborder"  height="18px" align=left>4b</td> <td class="normalborder"  height="18px" align=left>4c</td> <td class="normalborder"  height="18px" align=left>4d</td> </tr>'#$D#$A'</table><!--EndFragment--></body></html>';
-  LCompareSuccessful := LText = LExpected;
-  Assert.IsTrue(LCompareSuccessful, 'Clipboard text is unexpected!');
+  LExpected := BuildExpectedCellHTML([n3, n4]);
+  Assert.AreEqual(LExpected, LText, 'Clipboard HTML does not match the export template!');
 end;
 
 procedure TCellSelectionTests.TestCopyHTML2;
@@ -603,7 +651,6 @@ var
   n3, n5: PVirtualNode;
   LText, LExpected: string;
   LTries: Integer;
-  LCompareSuccessful: LongBool;
 begin
   LTree := FTree;
   LTree.Font.Name := 'Tahoma';
@@ -642,18 +689,8 @@ begin
     end;
     // End unnecessary stuff
   until (LText <> '') or (LTries > MaxTries);
-  LExpected := 'Version:1.0'#$D#$A'StartHTML:00000097'#$D#$A'EndHTML:00001947'#$D#$A'StartFragment:00000269'#$D#$A'EndFragment:00001915'#$D#$A'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"><html><head>'+
-  '<META http-equiv=Content-Type content="text/html; charset=utf-8"></head><body><!--StartFragment--><META http-equiv="Content-Type" content="text/html; charset=utf-8"><style type="text/css">'#$D#$A+
-  '.default{font-family: ''Tahoma''; font-size: 10pt; font-style: normal; font-weight: normal; text-decoration: none; color: #000000;}'#$D#$A+
-  '.header{font-family: ''Tahoma''; font-size: 10pt; font-style: normal; font-weight: normal; text-decoration: none; color: #000000;}'#$D#$A'.noborder{border-style: none;padding-left: 4px; padding-right: 4px;}'#$D#$A+
-  '.normalborder {vertical-align: top; border-right: none; border-left:none; border-top:none; border-bottom: none;border-width: thin; border-style: dotted;padding-left: 4px; padding-right: 4px;}</style>'#$D#$A +
-  '<table class="default" style="border-collapse: collapse;" bgcolor=#FFFFFF  border="1" frame=box cellspacing="0">'#$D#$A'<tr class="header" style="padding-left: 4px; padding-right: 4px;">'#$D#$A+
-  '<th height="20px" align=left bgcolor=#F0F0F0 width="50px">col2</th><th height="20px" align=left bgcolor=#F0F0F0 width="50px">col3</th><th height="20px" align=left bgcolor=#F0F0F0 width="50px">col4</th></tr>'#$D#$A+
-  ' <tr class="default">'#$D#$A' <td class="normalborder"  height="18px" align=left>3b</td> <td class="normalborder"  height="18px" align=left>3c</td> <td class="normalborder"  height="18px" align=left>3d</td> </tr>'#$D#$A+
-  ' <tr class="default">'#$D#$A' <td class="normalborder"  height="18px" align=left>4b</td> <td class="normalborder"  height="18px" align=left>4c</td> <td class="normalborder"  height="18px" align=left>4d</td> </tr>'#$D#$A' <tr class="default">'#$D#$A +
-  ' <td class="normalborder"  height="18px" align=left>5b</td> <td class="normalborder"  height="18px" align=left>5c</td> <td class="normalborder"  height="18px" align=left>5d</td> </tr>'#$D#$A'</table><!--EndFragment--></body></html>';
-  LCompareSuccessful := LText = LExpected;
-  Assert.IsTrue(LCompareSuccessful, 'Clipboard text is unexpected!');
+  LExpected := BuildExpectedCellHTML([n3, FNode4, n5]);
+  Assert.AreEqual(LExpected, LText, 'Clipboard HTML does not match the export template!');
 end;
 
 procedure TCellSelectionTests.TestCopyPlainText1;


### PR DESCRIPTION
The two `TestCopyHTML` tests have been permanently red on standard-dpi machines since their introduction. They compare the CF_HTML clipboard content byte-by-byte against hardcoded strings whose pixel values come from the machine the fixture was created on - the test form's dfm carries `PixelsPerInch = 216` (DefaultNodeHeight 46, TextMargin 9, ...). On a 96 dpi machine the dpi-rescale chain yields a node height of 19 instead of 18, and the *only* difference in the whole comparison is `height="18px"` vs `height="19px"` in the data rows (the CF_HTML offsets happen to still match because both values have two digits).

The expected string is now built from the tree's actual metrics - font, `Header.Height`, column widths and captions, `NodeHeight[]`, `Text[]` - i.e. the same sources the HTML exporter reads, and the fixed-width CF_HTML offset header is computed exactly like `MakeFragment` in `VirtualTrees.Export.pas`. The comparison stays byte-exact, so any change to the export format still fails the test - only the machine dependency is gone. `Assert.AreEqual` now also reports the actual difference instead of a plain boolean message.

With this the suite is fully green for the first time: **153/153 on Delphi 13.1 and on 10 Seattle** (the oldest claimed supported version, both 96 dpi). Should be green on high-dpi machines as well since all values are derived from the running tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)