### PR TITLE
Register the accessibility providers by default (issue #873)

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -609,7 +609,13 @@ uses
   VirtualTrees.Utils,
   VirtualTrees.Export,
   VirtualTrees.EditLink,
-  VirtualTrees.BaseAncestorVcl{to eliminate H2443 about inline expanding}
+  VirtualTrees.BaseAncestorVcl{to eliminate H2443 about inline expanding},
+  // Issue #873: reference the accessibility unit so its initialization registers the
+  // default MSAA providers. Without this nothing links it in Delphi (only a
+  // C++Builder $HPPEMIT pragma in VirtualTrees.BaseTree does), so screen-reader
+  // support stayed inactive until an application added the unit to a uses clause
+  // itself. Creating the IAccessible objects still happens lazily on WM_GETOBJECT.
+  VirtualTrees.Accessibility
   ;
 
 const


### PR DESCRIPTION
Fixes #873.

### Problem

Screen-reader support was effectively off out of the box. `VirtualTrees.Accessibility` registers the default MSAA `IAccessible` providers in its `initialization` section, but **nothing links that unit in Delphi** - only a C++Builder `{$HPPEMIT '#pragma link "VirtualTrees.Accessibility"'}` in `VirtualTrees.BaseTree` references it. So the providers never registered, `WM_GETOBJECT` returned no tree accessible, and screen readers saw only the generic window. Applications had to add the unit to a `uses` clause themselves (as noted by the reporters in the discussion).

### Change

Reference `VirtualTrees.Accessibility` from the `VirtualTrees` umbrella unit's implementation `uses`, so the providers register automatically. The `IAccessible` objects are still created lazily on `WM_GETOBJECT`, so there is no cost until an accessibility client attaches.

### On the original keyboard-navigation report

Measured on current `master` with **NVDA**: once accessibility is active, arrowing through nodes **is** announced - `DoFocusChange` firing `EVENT_OBJECT_FOCUS` (added since this issue was opened) already does the job. I could not reproduce the "keyboard navigation is silent" symptom, so it looks like the 2019 report was the unit-not-linked problem this PR fixes, rather than a missing notification.

(I also tried firing the focus event against the item's child id instead of `CHILDID_SELF`; it made no difference and is inconsistent with the object-child model - `TVirtualTreeItemAccessibility.Get_accFocus` deliberately returns `CHILDID_SELF` to avoid a Narrator loop - so I did not pursue it.)

### Testing

- New auto-registration check: an app using **only** `VirtualTrees` (not `VirtualTrees.Accessibility`) now gets the tree's own `IAccessible` back from `AccessibleObjectFromWindow`.
- Keyboard navigation announced by NVDA.
- Compiles Delphi 7 through 13.1; existing DUnitX suite stays green.
